### PR TITLE
NetworkDetector: Improve packaging and error handling

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -409,6 +409,7 @@ Depends: ${shlibs:Depends},
          ${misc:Depends},
          nmap,
          fping,
+         arping,
          nymea-plugins-translations,
 Replaces: guh-plugin-networkdetector
 Description: nymea.io plugin for networkdetector

--- a/networkdetector/devicemonitor.cpp
+++ b/networkdetector/devicemonitor.cpp
@@ -16,12 +16,15 @@ DeviceMonitor::DeviceMonitor(const QString &name, const QString &macAddress, con
 
     m_arpingProcess = new QProcess(this);
     m_arpingProcess->setReadChannelMode(QProcess::MergedChannels);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
+    // Actually we'd need this fix on older platforms too, but it's hard to figure this out without this API...
     connect(m_arpingProcess, &QProcess::errorOccurred, this, [this](QProcess::ProcessError error) {
         if (error == QProcess::FailedToStart) {
             warn(QString("arping process failed to start. Falling back to ping. This plugin might not work properly on this system."));
             ping();
         }
     });
+#endif
     connect(m_arpingProcess, SIGNAL(finished(int)), this, SLOT(arpingFinished(int)));
 
     m_pingProcess = new QProcess(this);

--- a/networkdetector/devicemonitor.cpp
+++ b/networkdetector/devicemonitor.cpp
@@ -16,6 +16,12 @@ DeviceMonitor::DeviceMonitor(const QString &name, const QString &macAddress, con
 
     m_arpingProcess = new QProcess(this);
     m_arpingProcess->setReadChannelMode(QProcess::MergedChannels);
+    connect(m_arpingProcess, &QProcess::errorOccurred, this, [this](QProcess::ProcessError error) {
+        if (error == QProcess::FailedToStart) {
+            warn(QString("arping process failed to start. Falling back to ping. This plugin might not work properly on this system."));
+            ping();
+        }
+    });
     connect(m_arpingProcess, SIGNAL(finished(int)), this, SLOT(arpingFinished(int)));
 
     m_pingProcess = new QProcess(this);


### PR DESCRIPTION
On the new buster image, arping isn't installed. This causes the plugin to break completely and prevent it from marking devices as gone.

a) add a dependency to arping to make it work properly on buster
b) prevent it from breaking completely even on setups without arping (e.g. self compiled)

nymea-plugins pull request checklist:

* Did you test the changes on hardware, if not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

Yes, tested on a buster rpi4

* Did you update the plugin's README.md accordingly?

No changes needed

* Did you update translations (`cd builddir && make lupdate`)?

No string changes

* If you added a new plugin, should it be added to nymea-plugins-all or nymea-plugins-maker?

N/A