### PR TITLE
UsbRelay: Fix initialization of udev device watcher if no matching device is connected

### DIFF
--- a/usbrelay/rawhiddevicewatcher.cpp
+++ b/usbrelay/rawhiddevicewatcher.cpp
@@ -84,17 +84,7 @@ RawHidDeviceWatcher::RawHidDeviceWatcher(QObject *parent) : QObject(parent)
 
     udev_enumerate_add_match_subsystem(enumerate, "hidraw");
     udev_enumerate_scan_devices(enumerate);
-
     devices = udev_enumerate_get_list_entry(enumerate);
-    if (!devices) {
-        qCWarning(dcUsbRelay()) << "Failed to get hidraw devices from udev enumerate.";
-        udev_monitor_unref(m_monitor);
-        m_monitor = nullptr;
-        udev_unref(m_udev);
-        m_udev = nullptr;
-        return;
-    }
-
     udev_list_entry_foreach(dev_list_entry, devices) {
         struct udev_device *thing;
         const char *path;


### PR DESCRIPTION
nymea-plugins pull request checklist:

- [x] Make sure the pull request's title is of format "Plugin name: Add support for xyz" or "New plugin: Plugin name"

- [x] Did you test the changes on hardware, if not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [x] Did you update the plugin's README.md accordingly?

- [x] Did you update translations (`cd builddir && make lupdate`)?

- [x] If you added a new plugin, should it be added to nymea-plugins-all or nymea-plugins-maker?
