### PR TITLE
Don't use API deprecated in Qt 5.14

### DIFF
--- a/datetime/integrationplugindatetime.cpp
+++ b/datetime/integrationplugindatetime.cpp
@@ -415,8 +415,8 @@ void IntegrationPluginDateTime::onDayChanged(const QDateTime &dateTime)
     m_todayDevice->setStateValue(todayMonthStateTypeId, dateTime.date().month());
     m_todayDevice->setStateValue(todayYearStateTypeId, dateTime.date().year());
     m_todayDevice->setStateValue(todayWeekdayStateTypeId, dateTime.date().dayOfWeek());
-    m_todayDevice->setStateValue(todayWeekdayNameStateTypeId, dateTime.date().longDayName(dateTime.date().dayOfWeek()));
-    m_todayDevice->setStateValue(todayMonthNameStateTypeId, dateTime.date().longMonthName(dateTime.date().month()));
+    m_todayDevice->setStateValue(todayWeekdayNameStateTypeId, QLocale().dayName(dateTime.date().dayOfWeek()));
+    m_todayDevice->setStateValue(todayMonthNameStateTypeId, QLocale().monthName(dateTime.date().month()));
     if(dateTime.date().dayOfWeek() == 6 || dateTime.date().dayOfWeek() == 7){
         m_todayDevice->setStateValue(todayWeekendStateTypeId, true);
     }else{

--- a/networkdetector/devicemonitor.cpp
+++ b/networkdetector/devicemonitor.cpp
@@ -45,7 +45,7 @@ DeviceMonitor::DeviceMonitor(const QString &name, const QString &macAddress, con
     connect(m_arpLookupProcess, SIGNAL(finished(int)), this, SLOT(arpLookupFinished(int)));
 
     m_arpingProcess = new QProcess(this);
-    m_arpingProcess->setReadChannelMode(QProcess::MergedChannels);
+    m_arpingProcess->setProcessChannelMode(QProcess::MergedChannels);
 #if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
     // Actually we'd need this fix on older platforms too, but it's hard to figure this out without this API...
     connect(m_arpingProcess, &QProcess::errorOccurred, this, [this](QProcess::ProcessError error) {
@@ -58,7 +58,7 @@ DeviceMonitor::DeviceMonitor(const QString &name, const QString &macAddress, con
     connect(m_arpingProcess, SIGNAL(finished(int)), this, SLOT(arpingFinished(int)));
 
     m_pingProcess = new QProcess(this);
-    m_pingProcess->setReadChannelMode(QProcess::MergedChannels);
+    m_pingProcess->setProcessChannelMode(QProcess::MergedChannels);
     connect(m_pingProcess, SIGNAL(finished(int)), this, SLOT(pingFinished(int)));
 }
 

--- a/shelly/integrationpluginshelly.cpp
+++ b/shelly/integrationpluginshelly.cpp
@@ -624,11 +624,11 @@ void IntegrationPluginShelly::setupShellyGateway(ThingSetupInfo *info)
     QHostAddress address;
     pluginStorage()->beginGroup(info->thing()->id().toString());
     if (zeroConfEntry.isValid()) {
-        address = zeroConfEntry.hostAddress().toString();
+        address = zeroConfEntry.hostAddress();
         pluginStorage()->setValue("cachedAddress", address.toString());
     } else {
         qCWarning(dcShelly()) << "Could not find Shelly thing on zeroconf. Trying cached address.";
-        address = pluginStorage()->value("cachedAddress").toString();
+        address = QHostAddress(pluginStorage()->value("cachedAddress").toString());
     }
     pluginStorage()->endGroup();
 


### PR DESCRIPTION
nymea-plugins pull request checklist:

- [x] Make sure the pull request's title is of format "Plugin name: Add support for xyz" or "New plugin: Plugin name"

- [x] Did you test the changes on hardware, if not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [x] Did you update the plugin's README.md accordingly?

- [x] Did you update translations (`cd builddir && make lupdate`)?

- [x] If you added a new plugin, should it be added to nymea-plugins-all or nymea-plugins-maker?
