### PR TITLE
Tasmota: Fix wrong param types for channels

### DIFF
--- a/tasmota/integrationplugintasmota.json
+++ b/tasmota/integrationplugintasmota.json
@@ -348,13 +348,13 @@
                             "id": "4d8f113d-f816-4356-b1ff-31df3f4b515f",
                             "name": "openingChannel",
                             "displayName": "Opening channel",
-                            "type": "int"
+                            "type": "QString"
                         },
                         {
                             "id": "600c00fd-6a2c-46cd-8031-2d9a1b1bc710",
                             "name": "closingChannel",
                             "displayName": "Closing channel",
-                            "type": "int"
+                            "type": "QString"
                         }
                     ],
                     "stateTypes": [
@@ -407,13 +407,13 @@
                             "id": "d8f26857-6a6c-4aba-8301-dbd3ba68bc28",
                             "name": "openingChannel",
                             "displayName": "Opening channel",
-                            "type": "int"
+                            "type": "QString"
                         },
                         {
                             "id": "32d0a914-e4df-4cac-bf70-304d7130f5f6",
                             "name": "closingChannel",
                             "displayName": "Closing channel",
-                            "type": "int"
+                            "type": "QString"
                         }
                     ],
                     "stateTypes": [


### PR DESCRIPTION
The channels are "POWER", "POWER0", "POWER1" etc... so they're
strings, not integers.

We could also use integers, however, that would require special handling
for the single channel (only "POWER" without number) on every publish,
this way we can do that just once in the setup and be done with it.

nymea-plugins pull request checklist:

- [x] Make sure the pull request's title is of format "Plugin name: Add support for xyz" or "New plugin: Plugin name"

- [x] Did you test the changes on hardware, if not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [x] Did you update the plugin's README.md accordingly?

- [x] Did you update translations (`cd builddir && make lupdate`)?

- [x] If you added a new plugin, should it be added to nymea-plugins-all or nymea-plugins-maker?
