### PR TITLE
Fix some plugins that fail the new, more strict param validation

### DIFF
--- a/genericthings/integrationplugingenericthings.json
+++ b/genericthings/integrationplugingenericthings.json
@@ -918,7 +918,7 @@
                     "name": "co2Sensor",
                     "displayName": "Generic CO2 sensor",
                     "createMethods": ["user"],
-                    "interfaces": ["co2Sensor"],
+                    "interfaces": ["co2sensor"],
                     "settingsTypes": [
                         {
                             "id": "a0d8a6ec-599a-4ded-ae03-2950561f0b72",

--- a/serialportcommander/integrationpluginserialportcommander.json
+++ b/serialportcommander/integrationpluginserialportcommander.json
@@ -95,7 +95,8 @@
                                     "name": "outputData",
                                     "displayName": "Data",
                                     "type": "QString",
-                                    "inputType": "TextArea"
+                                    "inputType": "TextArea",
+                                    "defaultValue": ""
                                 }
                             ]
                         }

--- a/simulation/integrationpluginsimulation.json
+++ b/simulation/integrationpluginsimulation.json
@@ -613,7 +613,8 @@
                                         "MiddleFingerRight",
                                         "RingFingerRight",
                                         "PinkyRight"
-                                    ]
+                                    ],
+                                    "defaultValue": "IndexFingerRight"
                                 }
                             ]
                         },

--- a/tcpcommander/integrationplugintcpcommander.json
+++ b/tcpcommander/integrationplugintcpcommander.json
@@ -52,7 +52,8 @@
                                     "name": "outputDataArea",
                                     "displayName": "Data",
                                     "type": "QString",
-                                    "inputType": "TextArea"
+                                    "inputType": "TextArea",
+                                    "defaultValue": ""
                                 }
                             ]
                         }

--- a/udpcommander/integrationpluginudpcommander.json
+++ b/udpcommander/integrationpluginudpcommander.json
@@ -76,7 +76,8 @@
                                     "id": "6604c852-6b24-4707-b8e5-1ddd8032efcc",
                                     "name": "data",
                                     "displayName": "Data",
-                                    "type": "QString"
+                                    "type": "QString",
+                                    "defaultValue": ""
                                 }
                             ]
                         }


### PR DESCRIPTION
nymea-plugins pull request checklist:

- [x] Make sure the pull request's title is of format "Plugin name: Add support for xyz" or "New plugin: Plugin name"

- [x] Did you test the changes on hardware, if not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [x] Did you update the plugin's README.md accordingly?

- [x] Did you update translations (`cd builddir && make lupdate`)?

- [x] If you added a new plugin, should it be added to nymea-plugins-all or nymea-plugins-maker?
