### PR TITLE
Shelly: Fix occational crash when setup times out

### DIFF
--- a/shelly/integrationpluginshelly.cpp
+++ b/shelly/integrationpluginshelly.cpp
@@ -530,7 +530,7 @@ void IntegrationPluginShelly::onPublishReceived(MqttChannel *channel, const QStr
             qCWarning(dcShelly()) << qUtf8Printable(payload);
             return;
         }
-        qCDebug(dcShelly()) << "Payload:" << qUtf8Printable(jsonDoc.toJson());
+//        qCDebug(dcShelly()) << "Payload:" << qUtf8Printable(jsonDoc.toJson());
         QVariantMap data = jsonDoc.toVariant().toMap();
 
         // Wifi signal strength
@@ -553,7 +553,7 @@ void IntegrationPluginShelly::onPublishReceived(MqttChannel *channel, const QStr
 
 
     if (topic.startsWith("shellies/" + shellyId + "/input/")) {
-        qCDebug(dcShelly()) << "Payload:" << payload;
+//        qCDebug(dcShelly()) << "Payload:" << payload;
         int channel = topic.split("/").last().toInt();
         // "1" or "0"
         // Emit event button pressed
@@ -570,7 +570,7 @@ void IntegrationPluginShelly::onPublishReceived(MqttChannel *channel, const QStr
 
     QRegExp topicMatcher = QRegExp("shellies/" + shellyId + "/relay/[0-1]");
     if (topicMatcher.exactMatch(topic)) {
-        qCDebug(dcShelly()) << "Payload:" << payload;
+//        qCDebug(dcShelly()) << "Payload:" << payload;
         QStringList parts = topic.split("/");
         int channel = parts.at(3).toInt();
         bool on = payload == "on";
@@ -593,7 +593,7 @@ void IntegrationPluginShelly::onPublishReceived(MqttChannel *channel, const QStr
 
     topicMatcher = QRegExp("shellies/" + shellyId + "/(relay|roller)/[0-1]/power");
     if (topicMatcher.exactMatch(topic)) {
-        qCDebug(dcShelly()) << "Payload:" << payload;
+//        qCDebug(dcShelly()) << "Payload:" << payload;
         QStringList parts = topic.split("/");
         int channel = parts.at(3).toInt();
         double power = payload.toDouble();
@@ -612,7 +612,7 @@ void IntegrationPluginShelly::onPublishReceived(MqttChannel *channel, const QStr
 
     topicMatcher = QRegExp("shellies/" + shellyId + "/(relay|roller)/[0-1]/energy");
     if (topicMatcher.exactMatch(topic)) {
-        qCDebug(dcShelly()) << "Payload:" << payload;
+//        qCDebug(dcShelly()) << "Payload:" << payload;
         QStringList parts = topic.split("/");
         int channel = parts.at(3).toInt();
         // W/min => kW/h
@@ -631,7 +631,7 @@ void IntegrationPluginShelly::onPublishReceived(MqttChannel *channel, const QStr
     }
 
     if (topic == "shellies/" + shellyId + "/color/0") {
-        qCDebug(dcShelly()) << "Payload:" << payload;
+//        qCDebug(dcShelly()) << "Payload:" << payload;
         bool on = payload == "on";
         if (m_powerStateTypeMap.contains(thing->thingClassId())) {
             thing->setStateValue(m_powerStateTypeMap.value(thing->thingClassId()), on);
@@ -639,7 +639,7 @@ void IntegrationPluginShelly::onPublishReceived(MqttChannel *channel, const QStr
     }
 
     if (topic == "shellies/" + shellyId + "/color/0/status") {
-        qCDebug(dcShelly()) << "Payload:" << payload;
+//        qCDebug(dcShelly()) << "Payload:" << payload;
         QJsonParseError error;
         QJsonDocument jsonDoc = QJsonDocument::fromJson(payload, &error);
         if (error.error != QJsonParseError::NoError) {
@@ -662,7 +662,7 @@ void IntegrationPluginShelly::onPublishReceived(MqttChannel *channel, const QStr
     }
 
     if (topic == "shellies/" + shellyId + "/light/0") {
-        qCDebug(dcShelly()) << "Payload:" << payload;
+//        qCDebug(dcShelly()) << "Payload:" << payload;
         bool on = payload == "on";
         if (m_powerStateTypeMap.contains(thing->thingClassId())) {
             thing->setStateValue(m_powerStateTypeMap.value(thing->thingClassId()), on);
@@ -676,7 +676,7 @@ void IntegrationPluginShelly::onPublishReceived(MqttChannel *channel, const QStr
             qCWarning(dcShelly()) << "Error parsing JSON from Shelly:" << error.error << error.errorString() << payload;
             return;
         }
-        qCDebug(dcShelly()) << "Payload:" << qUtf8Printable(jsonDoc.toJson());
+//        qCDebug(dcShelly()) << "Payload:" << qUtf8Printable(jsonDoc.toJson());
         QVariantMap statusMap = jsonDoc.toVariant().toMap();
         if (m_brightnessStateTypeMap.contains(thing->thingClassId())) {
             int brightness = statusMap.value("brightness").toInt();
@@ -685,7 +685,7 @@ void IntegrationPluginShelly::onPublishReceived(MqttChannel *channel, const QStr
     }
 
     if (topic == "shellies/" + shellyId + "/light/0/power") {
-        qCDebug(dcShelly()) << "Payload:" << payload;
+//        qCDebug(dcShelly()) << "Payload:" << payload;
         if (m_currentPowerStateTypeMap.contains(thing->thingClassId())) {
             double power = payload.toDouble();
             thing->setStateValue(m_currentPowerStateTypeMap.value(thing->thingClassId()), power);
@@ -693,14 +693,14 @@ void IntegrationPluginShelly::onPublishReceived(MqttChannel *channel, const QStr
     }
 
     if (topic == "shellies/" + shellyId + "/roller/0") {
-        qCDebug(dcShelly()) << "Payload:" << payload;
+//        qCDebug(dcShelly()) << "Payload:" << payload;
         // Roller shutters are always child devices...
         foreach (Thing *child, myThings().filterByParentId(thing->id()).filterByInterface("extendedshutter")) {
             child->setStateValue(shellyRollerMovingStateTypeId, payload != "stop");
         }
     }
     if (topic == "shellies/" + shellyId + "/roller/0/pos") {
-        qCDebug(dcShelly()) << "Payload:" << payload;
+//        qCDebug(dcShelly()) << "Payload:" << payload;
         // Roller shutters are always child devices...
         int pos = payload.toInt();
         foreach (Thing *child, myThings().filterByParentId(thing->id()).filterByInterface("extendedshutter")) {
@@ -808,14 +808,23 @@ void IntegrationPluginShelly::setupShellyGateway(ThingSetupInfo *info)
     QNetworkReply *reply = hardwareManager()->networkManager()->get(request);
     connect(reply, &QNetworkReply::finished, reply, &QNetworkReply::deleteLater);
     connect(info, &ThingSetupInfo::aborted, channel, [this, channel, thing](){
+        qCWarning(dcShelly()) << "Setup for" << thing->name() << "aborted.";
         hardwareManager()->mqttProvider()->releaseChannel(channel);
         m_mqttChannels.remove(thing);
     });
     connect(reply, &QNetworkReply::finished, info, [this, info, reply, channel, address](){
         if (reply->error() != QNetworkReply::NoError) {
-            hardwareManager()->mqttProvider()->releaseChannel(channel);
-            m_mqttChannels.remove(info->thing());
-            qCWarning(dcShelly()) << "Error fetching thing settings" << reply->error() << reply->errorString();
+            qCWarning(dcShelly()) << "Error fetching thing settings for" << info->thing()->name() << reply->error() << reply->errorString();
+            // Given the networkManagers timeout is the same as the info timeout (30s) and they are
+            // both started in the same event loop pass, they'll also time out in the same event loop pass
+            // and it happens we'll get both, ThingSetupInfo::aborted *and* QNetworkReply::finished (with the
+            // aborted flag) which both clean up the MQTT channel. Make sure to check if it's still there
+            // before actually cleaning up. We can't remove any of the cleanups as that might cause leaks if
+            // either the network reply finishes with an earlier error, or the setup is aborted earlier.
+            if (m_mqttChannels.contains(info->thing())) {
+                hardwareManager()->mqttProvider()->releaseChannel(channel);
+                m_mqttChannels.remove(info->thing());
+            }
             if (reply->error() == QNetworkReply::AuthenticationRequiredError) {
                 info->finish(Thing::ThingErrorAuthenticationFailure, QT_TR_NOOP("Username and password not set correctly."));
             } else {
@@ -919,7 +928,7 @@ void IntegrationPluginShelly::setupShellyGateway(ThingSetupInfo *info)
                         rollerShutterChild.setParams(ParamList() << Param(shellyRollerThingChannelParamTypeId, 1));
                         autoChilds.append(rollerShutterChild);
                     }
-                }                
+                }
             }
         }
 


### PR DESCRIPTION
There's a crash when the mqtt channel is released twice if the shelly has poor wifi reception and network requests to it during the setup time out.

Not fixed yet. Adding some debug prints to understand in detail how that happens.

nymea-plugins pull request checklist:

- [x] Make sure the pull request's title is of format "Plugin name: Add support for xyz" or "New plugin: Plugin name"

- [x] Did you test the changes on hardware, if not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [x] Did you update the plugin's README.md accordingly?

- [x] Did you update translations (`cd builddir && make lupdate`)?

- [x] If you added a new plugin, should it be added to nymea-plugins-all or nymea-plugins-maker?
