### PR TITLE
Nuimo: Remove Battery Critical state

### DIFF
--- a/senic/integrationpluginsenic.cpp
+++ b/senic/integrationpluginsenic.cpp
@@ -105,7 +105,6 @@ void IntegrationPluginSenic::setupThing(ThingSetupInfo *info)
     connect(nuimo, &Nuimo::rotationValueChanged, this, &IntegrationPluginSenic::onRotationValueChanged);
     connect(nuimo, &Nuimo::connectedChanged, this, &IntegrationPluginSenic::onConnectedChanged);
     connect(nuimo, &Nuimo::deviceInformationChanged, this, &IntegrationPluginSenic::onDeviceInformationChanged);
-    connect(nuimo, &Nuimo::batteryValueChanged, this, &IntegrationPluginSenic::onBatteryValueChanged);
 
     m_nuimos.insert(nuimo, thing);
 
@@ -324,10 +323,3 @@ void IntegrationPluginSenic::onPluginConfigurationChanged(const ParamTypeId &par
     }
 }
 
-void IntegrationPluginSenic::onBatteryValueChanged(const uint &percentage)
-{
-    Nuimo *nuimo = static_cast<Nuimo *>(sender());
-    Thing *thing = m_nuimos.value(nuimo);
-
-    thing->setStateValue(nuimoBatteryLevelStateTypeId, percentage);
-}

--- a/senic/integrationpluginsenic.cpp
+++ b/senic/integrationpluginsenic.cpp
@@ -330,9 +330,4 @@ void IntegrationPluginSenic::onBatteryValueChanged(const uint &percentage)
     Thing *thing = m_nuimos.value(nuimo);
 
     thing->setStateValue(nuimoBatteryLevelStateTypeId, percentage);
-    if (percentage < 20) {
-        thing->setStateValue(nuimoBatteryCriticalStateTypeId, true);
-    } else {
-        thing->setStateValue(nuimoBatteryCriticalStateTypeId, false);
-    }
 }

--- a/senic/integrationpluginsenic.h
+++ b/senic/integrationpluginsenic.h
@@ -65,7 +65,6 @@ private slots:
     void onReconnectTimeout();
 
     void onConnectedChanged(bool connected);
-    void onBatteryValueChanged(const uint &percentage);
     void onButtonPressed();
     void onButtonLongPressed();
     void onSwipeDetected(const Nuimo::SwipeDirection &direction);

--- a/senic/integrationpluginsenic.json
+++ b/senic/integrationpluginsenic.json
@@ -29,7 +29,7 @@
                     "name": "nuimo",
                     "displayName": "Nuimo",
                     "createMethods": ["discovery"],
-                    "interfaces": ["simplemultibutton", "longpressbutton", "connectable", "batterylevel"],
+                    "interfaces": ["simplemultibutton", "longpressbutton", "connectable"],
                     "paramTypes": [
                         {
                             "id": "71553f6a-2ed4-4896-bb7b-52e7dca948b2",
@@ -71,17 +71,6 @@
                             "displayNameEvent": "Software revision changed",
                             "type": "QString",
                             "defaultValue": "-"
-                        },
-                        {
-                            "id": "b5ee2465-7fa1-450b-8073-f115537d3409",
-                            "name": "batteryLevel",
-                            "displayName": "Battery",
-                            "displayNameEvent": "Battery changed",
-                            "type": "int",
-                            "minValue": 0,
-                            "maxValue": 100,
-                            "unit": "Percentage",
-                            "defaultValue": 0
                         },
                         {
                             "id": "69a5f495-5452-434b-8fb8-b73d992c5446",

--- a/senic/integrationpluginsenic.json
+++ b/senic/integrationpluginsenic.json
@@ -73,14 +73,6 @@
                             "defaultValue": "-"
                         },
                         {
-                            "id": "aabd660f-b0c5-49f6-b7b0-6ba8e0a8cfcd",
-                            "name": "batteryCritical",
-                            "displayName": "Battery critical",
-                            "displayNameEvent": "Battery critical changed",
-                            "type": "bool",
-                            "defaultValue": true
-                        },
-                        {
                             "id": "b5ee2465-7fa1-450b-8073-f115537d3409",
                             "name": "batteryLevel",
                             "displayName": "Battery",

--- a/senic/nuimo.cpp
+++ b/senic/nuimo.cpp
@@ -314,17 +314,11 @@ void Nuimo::onConnectedChanged(bool connected)
         // Clean up services
         m_deviceInfoService->deleteLater();
 
-        // FIXME: As of BlueZ 5.48, the Battery service isn't expose in the same way any more.
-        // Until that's fixed m_batteryService might never be initialized
-        if (m_batteryService) {
-            m_batteryService->deleteLater();
-        }
 
         m_ledMatrixService->deleteLater();
         m_inputService->deleteLater();
 
         m_deviceInfoService = nullptr;
-        m_batteryService = nullptr;
         m_ledMatrixService = nullptr;
         m_inputService = nullptr;
     }
@@ -340,14 +334,6 @@ void Nuimo::onServiceDiscoveryFinished()
         emit deviceInitializationFinished(false);
         return;
     }
-
-    // FIXME: As of BlueZ 5.48, the Battery service isn't expose in the same way any more.
-    // For now we're deactivating this check to make the Nuimo still work despite the broken battery info
-//    if (!m_bluetoothDevice->serviceUuids().contains(QBluetoothUuid::BatteryService)) {
-//        qCWarning(dcSenic()) << "Battery service not found for device" << bluetoothDevice()->name() << bluetoothDevice()->address().toString();
-//        emit deviceInitializationFinished(false);
-//        return;
-//    }
 
     if (!m_bluetoothDevice->serviceUuids().contains(ledMatrinxServiceUuid)) {
         qCWarning(dcSenic()) << "Led matrix service not found for device" << bluetoothDevice()->name() << bluetoothDevice()->address().toString();
@@ -377,25 +363,22 @@ void Nuimo::onServiceDiscoveryFinished()
         }
     }
 
-    // Battery service
-    if (!m_batteryService) {
-        m_batteryService = m_bluetoothDevice->controller()->createServiceObject(QBluetoothUuid::BatteryService, this);
-        if (!m_batteryService) {
-            qCWarning(dcSenic()) << "Could not create battery service.";
 
             // FIXME: As of BlueZ 5.48, the Battery service isn't expose in the same way any more.
-            // For now we're deactivating this check to make the Nuimo still work despite the broken battery info
-//            emit deviceInitializationFinished(false);
+            // For now we're deactivating battery info
+/*            emit deviceInitializationFinished(false);
 //            return;
         } else {
-            connect(m_batteryService, &QLowEnergyService::stateChanged, this, &Nuimo::onBatteryServiceStateChanged);
-            connect(m_batteryService, &QLowEnergyService::characteristicChanged, this, &Nuimo::onBatteryCharacteristicChanged);
+//            connect(m_batteryService, &QLowEnergyService::stateChanged, this, &Nuimo::onBatteryServiceStateChanged);
+//            connect(m_batteryService, &QLowEnergyService::characteristicChanged, this, &Nuimo::onBatteryCharacteristicChanged);
 
-            if (m_batteryService->state() == QLowEnergyService::DiscoveryRequired) {
-                m_batteryService->discoverDetails();
-            }
+//            if (m_batteryService->state() == QLowEnergyService::DiscoveryRequired) {
+//                m_batteryService->discoverDetails();
+//            }
         }
     }
+*/
+
 
     // Input service
     if (!m_inputService) {
@@ -448,6 +431,7 @@ void Nuimo::onDeviceInfoServiceStateChanged(const QLowEnergyService::ServiceStat
     emit deviceInformationChanged(firmware, hardware, software);
 }
 
+/*
 void Nuimo::onBatteryServiceStateChanged(const QLowEnergyService::ServiceState &state)
 {
     // Only continue if discovered
@@ -479,6 +463,7 @@ void Nuimo::onBatteryCharacteristicChanged(const QLowEnergyCharacteristic &chara
         emit batteryValueChanged(batteryPercentage);
     }
 }
+*/
 
 void Nuimo::onInputServiceStateChanged(const QLowEnergyService::ServiceState &state)
 {

--- a/senic/nuimo.h
+++ b/senic/nuimo.h
@@ -76,12 +76,10 @@ private:
     BluetoothLowEnergyDevice *m_bluetoothDevice = nullptr;
 
     QLowEnergyService *m_deviceInfoService = nullptr;
-    QLowEnergyService *m_batteryService = nullptr;
     QLowEnergyService *m_inputService = nullptr;
     QLowEnergyService *m_ledMatrixService = nullptr;
 
     QLowEnergyCharacteristic m_deviceInfoCharacteristic;
-    QLowEnergyCharacteristic m_batteryCharacteristic;
     QLowEnergyCharacteristic m_ledMatrixCharacteristic;
     QLowEnergyCharacteristic m_inputButtonCharacteristic;
     QLowEnergyCharacteristic m_inputSwipeCharacteristic;
@@ -99,7 +97,6 @@ signals:
     void connectedChanged(bool connected);
     void buttonPressed();
     void buttonLongPressed();
-    void batteryValueChanged(const uint &percentage);
     void swipeDetected(const SwipeDirection &direction);
     void rotationValueChanged(const uint &value);
     void deviceInformationChanged(const QString &firmwareRevision, const QString &hardwareRevision, const QString &softwareRevision);
@@ -110,9 +107,6 @@ private slots:
     void onServiceDiscoveryFinished();
 
     void onDeviceInfoServiceStateChanged(const QLowEnergyService::ServiceState &state);
-
-    void onBatteryServiceStateChanged(const QLowEnergyService::ServiceState &state);
-    void onBatteryCharacteristicChanged(const QLowEnergyCharacteristic &characteristic, const QByteArray &value);
 
     void onInputServiceStateChanged(const QLowEnergyService::ServiceState &state);
     void onInputCharacteristicChanged(const QLowEnergyCharacteristic &characteristic, const QByteArray &value);


### PR DESCRIPTION
Removed the BatteryCriticalState since battery level is not conveyed right anyway.

nymea-plugins pull request checklist:

- [x] Make sure the pull request's title is of format "Plugin name: Add support for xyz" or "New plugin: Plugin name"

- [ ] Did you test the changes on hardware, if not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [x] Did you update the plugin's README.md accordingly?

- [x] Did you update translations (`cd builddir && make lupdate`)?

- [x] If you added a new plugin, should it be added to nymea-plugins-all or nymea-plugins-maker?
