### PR TITLE
Nuki: Always clean up after a failed setup

### DIFF
--- a/nuki/integrationpluginnuki.cpp
+++ b/nuki/integrationpluginnuki.cpp
@@ -167,7 +167,18 @@ void IntegrationPluginNuki::confirmPairing(ThingPairingInfo *info, const QString
 
     m_asyncSetupNuki->startAuthenticationProcess(info->transactionId());
     m_pairingInfo = info;
-    connect(info, &ThingPairingInfo::destroyed, this, [this] { m_pairingInfo = nullptr; });
+    connect(info, &ThingPairingInfo::destroyed, this, [this] {
+        m_pairingInfo = nullptr;
+
+        // FIXME: There are situations where the setup never returns (i.e. when the Bluetooth connection aborts)
+        // In order to always clean up and not block subsequent retries, we'll destry the setup object here but
+        // for a better user experience it should be handled properly and tell the user what wen't wrong instead
+        // of letting the setup time out.
+        if (m_asyncSetupNuki) {
+            m_asyncSetupNuki->deleteLater();
+            m_asyncSetupNuki = nullptr;
+        }
+    });
 }
 
 void IntegrationPluginNuki::postSetupThing(Thing *thing)


### PR DESCRIPTION
nymea-plugins pull request checklist:

- [x] Make sure the pull request's title is of format "Plugin name: Add support for xyz" or "New plugin: Plugin name"

- [ ] Did you test the changes on hardware, if not (e.g. absence of required hardware), please mention a person to confirm it has been tested.
@simonseres @t-mon Could one of you test this please? Here's a description what happens: https://forum.nymea.io/t/nuki-smartlock-cannot-connect/430/5?u=mzanetti

- [x] Did you update the plugin's README.md accordingly?

- [x] Did you update translations (`cd builddir && make lupdate`)?

- [x] If you added a new plugin, should it be added to nymea-plugins-all or nymea-plugins-maker?
