### PR TITLE
Fix qmake warning message if plugin.pri isn't found

### DIFF
--- a/plugins.pri
+++ b/plugins.pri
@@ -2,8 +2,8 @@ isEmpty(PLUGIN_PRI) {
   exists($$[QT_INSTALL_PREFIX]/include/nymea/plugin.pri) {
     include($$[QT_INSTALL_PREFIX]/include/nymea/plugin.pri)
   } else {
-    message("plugin.pri not found. Either install libnymea1-dev or use the PLUGIN_PRI argument to point to it.")
-    message("For building this project without nymea installed system-wide, you will want to export those variables in addition:")
+    message("plugin.pri not found. Either install nymea-sdk or use the PLUGIN_PRI argument to point to it.")
+    message("For building this project without the nymea-sdk installed system-wide, you will want to export those variables in addition:")
     message("PKG_CONFIG_PATH=/path/to/build-nymea/libnymea/pkgconfig/")
     message("CPATH=/path/to/nymea/libnymea/")
     message("LIBRARY_PATH=/path/to/build-nymea/libnymea/")


### PR DESCRIPTION
nymea-plugins pull request checklist:

- [x] Make sure the pull request's title is of format "Plugin name: Add support for xyz" or "New plugin: Plugin name"

- [x] Did you test the changes on hardware, if not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [x] Did you update the plugin's README.md accordingly?

- [x] Did you update translations (`cd builddir && make lupdate`)?

- [x] If you added a new plugin, should it be added to nymea-plugins-all or nymea-plugins-maker?
