### PR TITLE
Nuki: Fix bad if clause guards

### DIFF
--- a/bose/soundtouchtypes.h
+++ b/bose/soundtouchtypes.h
@@ -139,7 +139,7 @@ struct ContentItemObject {
     QString source;             //Attribute. The type or name of the service playing. To determine if the product is in standby mode, check if source == STANDBY.
     QString location;           //Attribute. READ-ONLY. This attribute is used by Bose to point to the content the user is accessing. You can save it to access content later, but do not attempt to generate your own locations.
     QString sourceAccount;      //Attribute. The user-account associated with this source.
-    bool isPresetable;          //Attribute. TRUE if the source can be set as one of the six (6) SoundTouch presets.
+    bool isPresetable = false;  //Attribute. TRUE if the source can be set as one of the six (6) SoundTouch presets.
     QString itemName;           //Element. The album, station, playlist, song, phone, etc. name depending on the source.
     QString containerArt;       //URL
 };

--- a/nuki/bluez/bluetoothmanager.cpp
+++ b/nuki/bluez/bluetoothmanager.cpp
@@ -180,10 +180,10 @@ void BluetoothManager::processInterfaceList(const QDBusObjectPath &objectPath, c
             if (properties.contains("Service")) {
                 QDBusObjectPath serviceObjectPath = qvariant_cast<QDBusObjectPath>(properties.value("Service"));
                 BluetoothGattService *service = findService(serviceObjectPath);
-                if (service)
+                if (service) {
                     qCDebug(dcBluez()) << "Add characteristic" << serviceObjectPath.path() << properties << service;
                     service->addCharacteristicInternally(objectPath, properties);
-
+                }
             }
         }
     }
@@ -196,10 +196,10 @@ void BluetoothManager::processInterfaceList(const QDBusObjectPath &objectPath, c
             if (properties.contains("Characteristic")) {
                 QDBusObjectPath characterisitcObjectPath = qvariant_cast<QDBusObjectPath>(properties.value("Characteristic"));
                 BluetoothGattCharacteristic *characteristic = findCharacteristic(characterisitcObjectPath);
-                if (characteristic)
+                if (characteristic) {
                     qCDebug(dcBluez()) << "Add descriptor" << characterisitcObjectPath.path() << properties << characteristic;
                     characteristic->addDescriptorInternally(objectPath, properties);
-
+                }
             }
         }
     }

--- a/sonos/integrationpluginsonos.cpp
+++ b/sonos/integrationpluginsonos.cpp
@@ -151,7 +151,6 @@ void IntegrationPluginSonos::confirmPairing(ThingPairingInfo *info, const QStrin
         if (!sonos) {
             qWarning(dcSonos()) << "No sonos connection found for thing:" << info->thingName();
             m_setupSonosConnections.remove(info->thingId());
-            sonos->deleteLater();
             info->finish(Thing::ThingErrorHardwareFailure);
             return;
         }

--- a/tado/tado.h
+++ b/tado/tado.h
@@ -67,20 +67,20 @@ public:
     };
 
     struct ZoneState {
-        bool connected;
-        bool power;
+        bool connected = false;
+        bool power = false;
         QString tadoMode;
         QString settingType;
-        double settingTemperature;
-        bool settingPower;
-        double temperature;
-        double humidity;
-        bool windowOpen;
-        double heatingPowerPercentage;
+        double settingTemperature = false;
+        bool settingPower = false;
+        double temperature = false;
+        double humidity = false;
+        bool windowOpen = false;
+        double heatingPowerPercentage = false;
         QString heatingPowerType;
-        bool overlayIsSet;
-        bool overlaySettingPower;
-        double overlaySettingTemperature;
+        bool overlayIsSet = false;
+        bool overlaySettingPower = false;
+        double overlaySettingTemperature = false;
         QString overlayType;
     };
 


### PR DESCRIPTION
nymea-plugins pull request checklist:

- [x] Make sure the pull request's title is of format "Plugin name: Add support for xyz" or "New plugin: Plugin name"

- [ ] Did you test the changes on hardware, if not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

Don't have a Nuki. If someone could test this.. Reasonably confident it didn't break anything though.

- [x] Did you update the plugin's README.md accordingly?

- [x] Did you update translations (`cd builddir && make lupdate`)?

- [x] If you added a new plugin, should it be added to nymea-plugins-all or nymea-plugins-maker?
