### PR TITLE
Osdomotics: Fix a crash if the plugin fails to load

### DIFF
--- a/osdomotics/integrationpluginosdomotics.cpp
+++ b/osdomotics/integrationpluginosdomotics.cpp
@@ -63,7 +63,9 @@ IntegrationPluginOsdomotics::IntegrationPluginOsdomotics()
 
 IntegrationPluginOsdomotics::~IntegrationPluginOsdomotics()
 {
-    hardwareManager()->pluginTimerManager()->unregisterTimer(m_pluginTimer);
+    if (m_pluginTimer) {
+        hardwareManager()->pluginTimerManager()->unregisterTimer(m_pluginTimer);
+    }
 }
 
 void IntegrationPluginOsdomotics::init()


### PR DESCRIPTION
Old code would crash if the plugin fails to load and is destroyed before init() is called.

nymea-plugins pull request checklist:

- [x] Make sure the pull request's title is of format "Plugin name: Add support for xyz" or "New plugin: Plugin name"

- [x] Did you test the changes on hardware, if not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [x] Did you update the plugin's README.md accordingly?

- [x] Did you update translations (`cd builddir && make lupdate`)?

- [x] If you added a new plugin, should it be added to nymea-plugins-all or nymea-plugins-maker?
