### PR TITLE
MecMeter: Optimize performance

### DIFF
--- a/mecelectronics/integrationpluginmecelectronics.json
+++ b/mecelectronics/integrationpluginmecelectronics.json
@@ -41,7 +41,8 @@
                             "displayNameEvent": "Current power consumption changed",
                             "type": "double",
                             "unit": "Watt",
-                            "defaultValue": 0
+                            "defaultValue": 0,
+                            "cached": false
                         },
                         {
                             "id": "2c36c0ce-1935-4fc7-84ad-b4e22335d7f7",
@@ -68,7 +69,9 @@
                             "displayNameEvent": "Phase A current changed",
                             "type": "double",
                             "unit": "Ampere",
-                            "defaultValue": 0
+                            "defaultValue": 0,
+                            "cached": false,
+                            "filter": "adaptive"
                         },
                         {
                             "id": "0aebf62a-fc9c-4457-8168-6a40c0227337",
@@ -77,7 +80,9 @@
                             "displayNameEvent": "Phase A voltage changed",
                             "type": "double",
                             "unit": "Volt",
-                            "defaultValue": 0
+                            "defaultValue": 0,
+                            "cached": false,
+                            "filter": "adaptive"
                         },
                         {
                             "id": "777ca8ed-623f-4aaa-8aaf-a0f3746ffc4d",
@@ -86,7 +91,8 @@
                             "displayNameEvent": "Phase A power changed",
                             "type": "double",
                             "unit": "Watt",
-                            "defaultValue": 0
+                            "defaultValue": 0,
+                            "cached": false
                         },
                         {
                             "id": "ae04176e-387e-4876-8e0c-32f8fa224595",
@@ -113,7 +119,8 @@
                             "displayNameEvent": "Phase B current changed",
                             "type": "double",
                             "unit": "Ampere",
-                            "defaultValue": 0
+                            "defaultValue": 0,
+                            "cached": false
                         },
                         {
                             "id": "4495030f-23e9-4013-ab00-d95fc8c2eb21",
@@ -122,7 +129,9 @@
                             "displayNameEvent": "Phase B voltage changed",
                             "type": "double",
                             "unit": "Volt",
-                            "defaultValue": 0
+                            "defaultValue": 0,
+                            "cached": false,
+                            "filter": "adaptive"
                         },
                         {
                             "id": "632998c0-28c5-4986-acaa-1a40b77efc9d",
@@ -131,7 +140,8 @@
                             "displayNameEvent": "Phase B power changed",
                             "type": "double",
                             "unit": "Watt",
-                            "defaultValue": 0
+                            "defaultValue": 0,
+                            "cached": false
                         },
                         {
                             "id": "e20911fb-e0a6-4fe6-a9f7-ecbb1ebb8ee7",
@@ -158,7 +168,8 @@
                             "displayNameEvent": "Phase C current changed",
                             "type": "double",
                             "unit": "Ampere",
-                            "defaultValue": 0
+                            "defaultValue": 0,
+                            "cached": false
                         },
                         {
                             "id": "fb8f5094-6d6b-44b7-b244-67614a7a06ff",
@@ -167,7 +178,9 @@
                             "displayNameEvent": "Phase C voltage changed",
                             "type": "double",
                             "unit": "Volt",
-                            "defaultValue": 0
+                            "defaultValue": 0,
+                            "cached": false,
+                            "filter": "adaptive"
                         },
                         {
                             "id": "333909a9-f28e-4e8a-a377-ff32fb80ae82",
@@ -176,7 +189,8 @@
                             "displayNameEvent": "Phase C power changed",
                             "type": "double",
                             "unit": "Watt",
-                            "defaultValue": 0
+                            "defaultValue": 0,
+                            "cached": false
                         },
                         {
                             "id": "ef43baf0-2f20-44d5-930d-528107c53cac",


### PR DESCRIPTION
nymea-plugins pull request checklist:
Given that this plugin polls a REST api every second, and all those values will change every time for a wee bit, this plugin is quite heavy on the resources for no real use.

-> Enable adaptive filtering for voltage states which are jittering but never really change
-> Disable caching for all volatile states. This gets away with *a lot* of unneeded disk IO and also seems to be the more correct thing to do.


- [x] Make sure the pull request's title is of format "Plugin name: Add support for xyz" or "New plugin: Plugin name"

- [x] Did you test the changes on hardware, if not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [x] Did you update the plugin's README.md accordingly?

- [x] Did you update translations (`cd builddir && make lupdate`)?

- [x] If you added a new plugin, should it be added to nymea-plugins-all or nymea-plugins-maker?
