### PR TITLE
somfytahoma: Use local connection "Somfy Developer Mode"

### DIFF
--- a/somfytahoma/README.md
+++ b/somfytahoma/README.md
@@ -22,5 +22,5 @@ entering your personal username + password for the Somfy TaHoma API.
 ## Supported devices
 
 Currently this plugin supports all roller shutters, blinds, garage
-door, awning drives and lights that are connectable to the TaHoma gateway.
-These are Somfy iO devices as well as RTS devices.
+door, awning drives, lights and smoke detectors that are connectable to the
+TaHoma gateway. These are Somfy iO devices as well as RTS devices.

--- a/somfytahoma/README.md
+++ b/somfytahoma/README.md
@@ -1,7 +1,11 @@
 # Somfy TaHoma
 
-This plugin adds support for Somfy smarthome devices through the Somfy TaHoma
-API.
+This plugin adds support for Somfy smarthome devices through the local
+Somfy TaHoma API offered by Somfy Gateways with 'Developer Mode'
+enabled.
+
+See <https://developer.somfy.com/developer-mode> and <https://github.com/Somfy-Developer/Somfy-TaHoma-Developer-Mode>
+for more information.
 
 ## Prerequisites
 

--- a/somfytahoma/integrationpluginsomfytahoma.cpp
+++ b/somfytahoma/integrationpluginsomfytahoma.cpp
@@ -98,8 +98,8 @@ void IntegrationPluginSomfyTahoma::confirmPairing(ThingPairingInfo *info, const 
                 info->finish(Thing::ThingErrorAuthenticationFailure, QT_TR_NOOP("Failed to activate token."));
             });
             connect(request, &SomfyTahomaRequest::finished, info, [this, info, username, password, token](const QVariant &result){
-                qCDebug(dcSomfyTahoma()) << "Got token uuid" << result;
                 QString requestId = result.toMap()["requestId"].toString();
+                qCDebug(dcSomfyTahoma()) << "Got token requestId" << requestId;
 
                 pluginStorage()->beginGroup(info->thingId().toString());
                 pluginStorage()->setValue("username", username);

--- a/somfytahoma/integrationpluginsomfytahoma.cpp
+++ b/somfytahoma/integrationpluginsomfytahoma.cpp
@@ -51,7 +51,7 @@ void IntegrationPluginSomfyTahoma::discoverThings(ThingDiscoveryInfo *info)
     foreach (const ZeroConfServiceEntry &entry, m_zeroConfBrowser->serviceEntries()) {
         qCDebug(dcSomfyTahoma()) << "Found local gateway:" << entry;
 
-        ThingDescriptor descriptor(info->thingClassId(), "Somfy Tahoma Gateway", entry.hostAddress().toString());
+        ThingDescriptor descriptor(info->thingClassId(), "Somfy TaHoma Gateway", entry.hostAddress().toString());
         ParamList params;
         params << Param(gatewayThingGatewayIdParamTypeId, entry.name());
         params << Param(gatewayThingGatewayPinParamTypeId, entry.txt("gateway_pin"));
@@ -71,7 +71,7 @@ void IntegrationPluginSomfyTahoma::discoverThings(ThingDiscoveryInfo *info)
 
 void IntegrationPluginSomfyTahoma::startPairing(ThingPairingInfo *info)
 {
-    info->finish(Thing::ThingErrorNoError, QT_TR_NOOP("Please enter the cloud login credentials for Somfy Tahoma in order to set up local access to the Gateway."));
+    info->finish(Thing::ThingErrorNoError, QT_TR_NOOP("Please enter the cloud login credentials for Somfy TaHoma in order to set up local access to the Gateway."));
 }
 
 void IntegrationPluginSomfyTahoma::confirmPairing(ThingPairingInfo *info, const QString &username, const QString &password)
@@ -79,7 +79,7 @@ void IntegrationPluginSomfyTahoma::confirmPairing(ThingPairingInfo *info, const 
     // Request local token from cloud account.
     SomfyTahomaRequest *request = createCloudSomfyTahomaLoginRequest(hardwareManager()->networkManager(), username, password, this);
     connect(request, &SomfyTahomaRequest::error, info, [info](){
-        info->finish(Thing::ThingErrorAuthenticationFailure, QT_TR_NOOP("Failed to login to Somfy Tahoma."));
+        info->finish(Thing::ThingErrorAuthenticationFailure, QT_TR_NOOP("Failed to login to Somfy TaHoma."));
     });
     connect(request, &SomfyTahomaRequest::finished, info, [this, info, username, password](const QVariant &/*result*/){
         SomfyTahomaRequest *request = createCloudSomfyTahomaGetRequest(hardwareManager()->networkManager(), "/config/" + info->params().paramValue(gatewayThingGatewayPinParamTypeId).toString() + "/local/tokens/generate", this);
@@ -119,7 +119,7 @@ void IntegrationPluginSomfyTahoma::setupThing(ThingSetupInfo *info)
     // Compatibility to older cloud based versions of the plugin.
     if (info->thing()->thingClassId() == tahomaThingClassId ||
             (info->thing()->thingClassId() == gatewayThingClassId && getToken(info->thing()).isEmpty())) {
-        info->finish(Thing::ThingErrorSetupFailed, QT_TR_NOOP("The Somfy Plugin switched to local connection. Please enable 'Developer Mode' on somfy.com, remove the account from Nymea and re-setup the Somfy Tahoma Gateway."));
+        info->finish(Thing::ThingErrorSetupFailed, QT_TR_NOOP("The Somfy Plugin switched to local connection. Please enable 'Developer Mode' on somfy.com, remove the account from Nymea and re-setup the Somfy TaHoma Gateway."));
         return;
     }
 

--- a/somfytahoma/integrationpluginsomfytahoma.h
+++ b/somfytahoma/integrationpluginsomfytahoma.h
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 *
-* Copyright 2013 - 2020, nymea GmbH
+* Copyright 2013 - 2022, nymea GmbH
 * Contact: contact@nymea.io
 *
 * This file is part of nymea.
@@ -34,6 +34,12 @@
 #include "integrations/integrationplugin.h"
 #include "plugintimer.h"
 
+#include "extern-plugininfo.h"
+
+class QHostAddress;
+
+class ZeroConfServiceBrowser;
+
 class SomfyTahomaRequest;
 
 class IntegrationPluginSomfyTahoma : public IntegrationPlugin
@@ -44,6 +50,9 @@ class IntegrationPluginSomfyTahoma : public IntegrationPlugin
     Q_INTERFACES(IntegrationPlugin)
 
 public:
+    void init() override;
+    void discoverThings(ThingDiscoveryInfo *info) override;
+
     void startPairing(ThingPairingInfo *info) override;
     void confirmPairing(ThingPairingInfo *info, const QString &username, const QString &password) override;
 
@@ -54,14 +63,16 @@ public:
     void executeAction(ThingActionInfo *info) override;
 
 private:
-    SomfyTahomaRequest *createLoginRequestWithStoredCredentials(Thing *thing);
-    void refreshAccount(Thing *thing);
-    void handleEvents(const QVariantList &eventList);
+    void refreshGateway(Thing *thing);
+    void handleEvents(const QVariantList &events);
     void updateThingStates(const QString &deviceUrl, const QVariantList &stateList);
     void markDisconnected(Thing *thing);
     void restoreChildConnectedState(Thing *thing);
+    QString getHost(Thing *thing) const;
+    QString getToken(Thing *thing) const;
 
 private:
+    ZeroConfServiceBrowser *m_zeroConfBrowser = nullptr;
     QMap<Thing *, PluginTimer *> m_eventPollTimer;
     QMap<QString, QPointer<ThingActionInfo>> m_pendingActions;
     QMap<QString, QList<Thing *>> m_currentExecutions;

--- a/somfytahoma/integrationpluginsomfytahoma.json
+++ b/somfytahoma/integrationpluginsomfytahoma.json
@@ -12,8 +12,7 @@
                     "id": "fedd72b8-547d-4e4f-b73e-71344a8ba0c1",
                     "name": "tahoma",
                     "displayName": "Tahoma Account",
-                    "createMethods": ["user"],
-                    "setupMethod": "userandpassword",
+                    "createMethods": ["auto"],
                     "interfaces": ["account"],
                     "stateTypes": [
                         {
@@ -46,14 +45,23 @@
                     "id": "6c09e0b9-f0cc-4dea-9994-9e039eff78f1",
                     "name": "gateway",
                     "displayName": "Tahoma Gateway",
-                    "createMethods": ["auto"],
+                    "createMethods": ["discovery"],
+                    "setupMethod": "userandpassword",
                     "interfaces": ["gateway"],
                     "paramTypes": [
                         {
                             "id": "e321a7d6-6dcb-4a37-baf1-c7008f2d5bdb",
                             "displayName": "Gateway Id",
                             "name": "gatewayId",
-                            "type": "QString"
+                            "type": "QString",
+                            "readOnly": true
+                        },
+                        {
+                            "id": "30b73244-e5bb-4c00-9332-702a60c03420",
+                            "displayName": "Gateway pin",
+                            "name": "gatewayPin",
+                            "type": "QString",
+                            "readOnly": true
                         }
                     ],
                     "stateTypes": [

--- a/somfytahoma/integrationpluginsomfytahoma.json
+++ b/somfytahoma/integrationpluginsomfytahoma.json
@@ -444,7 +444,61 @@
                             "defaultValue": false
                         }
                     ]
+                },
+                {
+                    "id": "e883a8ef-1fb7-4d7f-b40b-9cbc0133e58a",
+                    "name": "smokedetector",
+                    "displayName": "Smoke Detector",
+                    "createMethods": ["auto"],
+                    "interfaces": ["firesensor", "battery", "wirelessconnectable"],
+                    "paramTypes": [
+                        {
+                            "id": "3a41017b-87fe-4690-b148-1f69fac67f91",
+                            "displayName": "Device URL",
+                            "name": "deviceUrl",
+                            "type": "QString"
+                        }
+                    ],
+                    "stateTypes": [
+                        {
+                            "id": "6c3ee0ce-fc0f-477c-9a01-be61e061463b",
+                            "name": "fireDetected",
+                            "displayName": "Fire detected",
+                            "displayNameEvent": "Fire detected changed",
+                            "type": "bool",
+                            "defaultValue": false
+                        },
+                        {
+                            "id": "8f67b692-243b-4ce8-9983-0d1206439f16",
+                            "name": "batteryCritical",
+                            "displayName": "Battery critical",
+                            "displayNameEvent": "Battery critical changed",
+                            "type": "bool",
+                            "defaultValue": false
+                        },
+                        {
+                            "id": "47f8506c-af7f-4928-b0ce-8c52ce4f740b",
+                            "name": "signalStrength",
+                            "displayName": "Signal strength",
+                            "type": "uint",
+                            "unit": "Percentage",
+                            "displayNameEvent": "Signal strength changed",
+                            "minValue": 0,
+                            "maxValue": 100,
+                            "defaultValue": 0
+                        },
+                        {
+                            "id": "98cf101c-cb0e-47a9-9c27-b6a0cdf9ba4b",
+                            "name": "connected",
+                            "displayName": "Connected",
+                            "type": "bool",
+                            "displayNameEvent": "Connetion state changed",
+                            "defaultValue": false
+                        }
+                    ]
                 }
+
+
             ]
         }
     ]

--- a/somfytahoma/integrationpluginsomfytahoma.json
+++ b/somfytahoma/integrationpluginsomfytahoma.json
@@ -50,13 +50,6 @@
                     "interfaces": ["gateway"],
                     "paramTypes": [
                         {
-                            "id": "e321a7d6-6dcb-4a37-baf1-c7008f2d5bdb",
-                            "displayName": "Gateway Id",
-                            "name": "gatewayId",
-                            "type": "QString",
-                            "readOnly": true
-                        },
-                        {
                             "id": "30b73244-e5bb-4c00-9332-702a60c03420",
                             "displayName": "Gateway pin",
                             "name": "gatewayPin",

--- a/somfytahoma/integrationpluginsomfytahoma.json
+++ b/somfytahoma/integrationpluginsomfytahoma.json
@@ -1,6 +1,6 @@
 {
     "name": "SomfyTahoma",
-    "displayName": "Somfy Tahoma",
+    "displayName": "Somfy TaHoma",
     "id": "4e8be1c1-daa8-4e21-9e85-b2372ab1a450",
     "vendors": [
         {
@@ -11,7 +11,7 @@
                 {
                     "id": "fedd72b8-547d-4e4f-b73e-71344a8ba0c1",
                     "name": "tahoma",
-                    "displayName": "Tahoma Account",
+                    "displayName": "TaHoma Account",
                     "createMethods": ["auto"],
                     "interfaces": ["account"],
                     "stateTypes": [
@@ -44,7 +44,7 @@
                 {
                     "id": "6c09e0b9-f0cc-4dea-9994-9e039eff78f1",
                     "name": "gateway",
-                    "displayName": "Tahoma Gateway",
+                    "displayName": "TaHoma Gateway",
                     "createMethods": ["discovery"],
                     "setupMethod": "userandpassword",
                     "interfaces": ["gateway"],

--- a/somfytahoma/somfytahomarequests.h
+++ b/somfytahoma/somfytahomarequests.h
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 *
-* Copyright 2013 - 2020, nymea GmbH
+* Copyright 2013 - 2022, nymea GmbH
 * Contact: contact@nymea.io
 *
 * This file is part of nymea.
@@ -47,9 +47,14 @@ signals:
     void finished(const QVariant &results);
 };
 
-SomfyTahomaRequest *createSomfyTahomaPostRequest(NetworkAccessManager *networkManager, const QString &path, const QString &contentType, const QByteArray &body, QObject *parent);
-SomfyTahomaRequest *createSomfyTahomaGetRequest(NetworkAccessManager *networkManager, const QString &path, QObject *parent);
-SomfyTahomaRequest *createSomfyTahomaLoginRequest(NetworkAccessManager *networkManager, const QString &username, const QString &password, QObject *parent);
-SomfyTahomaRequest *createSomfyTahomaEventFetchRequest(NetworkAccessManager *networkManager, const QString &eventListenerId, QObject *parent);
+SomfyTahomaRequest *createCloudSomfyTahomaPostRequest(NetworkAccessManager *networkManager, const QString &path, const QString &contentType, const QByteArray &body, QObject *parent);
+SomfyTahomaRequest *createCloudSomfyTahomaGetRequest(NetworkAccessManager *networkManager, const QString &path, QObject *parent);
+SomfyTahomaRequest *createCloudSomfyTahomaDeleteRequest(NetworkAccessManager *networkManager, const QString &path, QObject *parent);
+SomfyTahomaRequest *createCloudSomfyTahomaLoginRequest(NetworkAccessManager *networkManager, const QString &username, const QString &password, QObject *parent);
+
+SomfyTahomaRequest *createLocalSomfyTahomaPostRequest(NetworkAccessManager *networkManager, const QString &host, const QString &token, const QString &path, const QString &contentType, const QByteArray &body, QObject *parent);
+SomfyTahomaRequest *createLocalSomfyTahomaGetRequest(NetworkAccessManager *networkManager, const QString &host, const QString &token, const QString &path, QObject *parent);
+SomfyTahomaRequest *createLocalSomfyTahomaEventFetchRequest(NetworkAccessManager *networkManager, const QString &host, const QString &token, const QString &eventListenerId, QObject *parent);
+
 
 #endif // SOMFYTAHOMAREQUESTS_H

--- a/somfytahoma/translations/4e8be1c1-daa8-4e21-9e85-b2372ab1a450-en_US.ts
+++ b/somfytahoma/translations/4e8be1c1-daa8-4e21-9e85-b2372ab1a450-en_US.ts
@@ -37,8 +37,8 @@
 <context>
     <name>SomfyTahoma</name>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="93"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="96"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="99"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="102"/>
         <source>Angle</source>
         <extracomment>The name of the ParamType (ThingClass: venetianblind, ActionType: angle, ID: {079c7a80-8a1c-4fd7-b40c-6800120c70fb})
 ----------
@@ -46,14 +46,14 @@ The name of the StateType ({079c7a80-8a1c-4fd7-b40c-6800120c70fb}) of ThingClass
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="99"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="105"/>
         <source>Awning</source>
         <extracomment>The name of the ThingClass ({d3a3bb40-4b2d-4bdc-989f-5254f03b4c90})</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="102"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="105"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="111"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="114"/>
         <source>Brightness</source>
         <extracomment>The name of the ParamType (ThingClass: light, ActionType: brightness, ID: {1b51ce68-1f7e-4f06-b68d-bfca2d61b353})
 ----------
@@ -61,10 +61,10 @@ The name of the StateType ({1b51ce68-1f7e-4f06-b68d-bfca2d61b353}) of ThingClass
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="108"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="111"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="114"/>
         <location filename="../../build/somfytahoma/plugininfo.h" line="117"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="120"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="123"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="126"/>
         <source>Close</source>
         <extracomment>The name of the ActionType ({20cae53b-f36d-425b-b937-3e46519893a3}) of ThingClass awning
 ----------
@@ -76,15 +76,18 @@ The name of the ActionType ({baf377c6-9fba-44cf-9f14-af0101f874b5}) of ThingClas
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="120"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="123"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="126"/>
         <location filename="../../build/somfytahoma/plugininfo.h" line="129"/>
         <location filename="../../build/somfytahoma/plugininfo.h" line="132"/>
         <location filename="../../build/somfytahoma/plugininfo.h" line="135"/>
         <location filename="../../build/somfytahoma/plugininfo.h" line="138"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="141"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="144"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="147"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="150"/>
         <source>Connected</source>
-        <extracomment>The name of the StateType ({fb8dcd84-70ad-4f3e-97c4-93296608e33d}) of ThingClass light
+        <extracomment>The name of the StateType ({98cf101c-cb0e-47a9-9c27-b6a0cdf9ba4b}) of ThingClass smokedetector
+----------
+The name of the StateType ({fb8dcd84-70ad-4f3e-97c4-93296608e33d}) of ThingClass light
 ----------
 The name of the StateType ({8f972969-10dd-4954-9c8b-de56070a6668}) of ThingClass awning
 ----------
@@ -100,13 +103,16 @@ The name of the StateType ({10ebf650-a93a-4ee3-945b-fba10d4e35a5}) of ThingClass
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="141"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="144"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="147"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="150"/>
         <location filename="../../build/somfytahoma/plugininfo.h" line="153"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="156"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="159"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="162"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="165"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="168"/>
         <source>Device URL</source>
-        <extracomment>The name of the ParamType (ThingClass: light, Type: thing, ID: {9cd2e0f2-a02f-478a-9358-6ff0f5aba9f5})
+        <extracomment>The name of the ParamType (ThingClass: smokedetector, Type: thing, ID: {3a41017b-87fe-4690-b148-1f69fac67f91})
+----------
+The name of the ParamType (ThingClass: light, Type: thing, ID: {9cd2e0f2-a02f-478a-9358-6ff0f5aba9f5})
 ----------
 The name of the ParamType (ThingClass: awning, Type: thing, ID: {ca60f12e-b9da-427a-a149-195922399fd5})
 ----------
@@ -118,34 +124,34 @@ The name of the ParamType (ThingClass: rollershutter, Type: thing, ID: {b3d20d6a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="156"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="174"/>
         <source>Garage Door</source>
         <extracomment>The name of the ThingClass ({cb206d74-b13c-4466-98c6-070b19ebd23a})</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="159"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="177"/>
         <source>Gateway Id</source>
         <extracomment>The name of the ParamType (ThingClass: gateway, Type: thing, ID: {e321a7d6-6dcb-4a37-baf1-c7008f2d5bdb})</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="165"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="183"/>
         <source>Light</source>
         <extracomment>The name of the ThingClass ({e569a3cc-6e79-4e24-af35-c5fa327a7314})</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="168"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="186"/>
         <source>Logged in</source>
         <extracomment>The name of the StateType ({97fefa85-db79-4efd-8d83-4a15d72996e1}) of ThingClass tahoma</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="171"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="174"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="177"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="180"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="189"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="192"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="195"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="198"/>
         <source>Moving</source>
         <extracomment>The name of the StateType ({2507ac5a-9658-42cb-80f6-73f673c32771}) of ThingClass awning
 ----------
@@ -157,10 +163,10 @@ The name of the StateType ({fa9446ba-da30-4d49-8fb6-f410ecc7dba0}) of ThingClass
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="183"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="186"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="189"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="192"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="201"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="204"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="207"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="210"/>
         <source>Open</source>
         <extracomment>The name of the ActionType ({9612954c-02cb-4159-9a29-f36eaf1c7f6a}) of ThingClass awning
 ----------
@@ -172,14 +178,14 @@ The name of the ActionType ({a0460180-e799-4bc6-83ba-11731ef124a3}) of ThingClas
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="195"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="198"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="201"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="204"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="207"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="210"/>
         <location filename="../../build/somfytahoma/plugininfo.h" line="213"/>
         <location filename="../../build/somfytahoma/plugininfo.h" line="216"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="219"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="222"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="225"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="228"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="231"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="234"/>
         <source>Percentage</source>
         <extracomment>The name of the ParamType (ThingClass: awning, ActionType: percentage, ID: {c409cb9b-82ef-4f59-ae89-eb783d4ebe97})
 ----------
@@ -199,8 +205,8 @@ The name of the StateType ({f954ffc7-a6aa-4d30-aee0-0484631c3344}) of ThingClass
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="219"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="222"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="237"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="240"/>
         <source>Power</source>
         <extracomment>The name of the ParamType (ThingClass: light, ActionType: power, ID: {654ddcdf-b0b7-4c38-a70d-878f0f3857a5})
 ----------
@@ -208,34 +214,46 @@ The name of the StateType ({654ddcdf-b0b7-4c38-a70d-878f0f3857a5}) of ThingClass
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="162"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="180"/>
         <source>Gateway pin</source>
         <extracomment>The name of the ParamType (ThingClass: gateway, Type: thing, ID: {30b73244-e5bb-4c00-9332-702a60c03420})</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="225"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="108"/>
+        <source>Battery critical</source>
+        <extracomment>The name of the StateType ({8f67b692-243b-4ce8-9983-0d1206439f16}) of ThingClass smokedetector</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="171"/>
+        <source>Fire detected</source>
+        <extracomment>The name of the StateType ({6c3ee0ce-fc0f-477c-9a01-be61e061463b}) of ThingClass smokedetector</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="243"/>
         <source>Roller Shutter</source>
         <extracomment>The name of the ThingClass ({6b187fe0-a987-462d-90ac-c48efc0d0fc0})</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="228"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="246"/>
         <source>Set angle</source>
         <extracomment>The name of the ActionType ({079c7a80-8a1c-4fd7-b40c-6800120c70fb}) of ThingClass venetianblind</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="231"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="249"/>
         <source>Set brightness</source>
         <extracomment>The name of the ActionType ({1b51ce68-1f7e-4f06-b68d-bfca2d61b353}) of ThingClass light</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="234"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="237"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="240"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="243"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="252"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="255"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="258"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="261"/>
         <source>Set percentage</source>
         <extracomment>The name of the ActionType ({c409cb9b-82ef-4f59-ae89-eb783d4ebe97}) of ThingClass awning
 ----------
@@ -247,19 +265,22 @@ The name of the ActionType ({f954ffc7-a6aa-4d30-aee0-0484631c3344}) of ThingClas
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="246"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="264"/>
         <source>Set power</source>
         <extracomment>The name of the ActionType ({654ddcdf-b0b7-4c38-a70d-878f0f3857a5}) of ThingClass light</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="249"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="252"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="255"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="258"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="261"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="267"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="270"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="273"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="276"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="279"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="282"/>
         <source>Signal strength</source>
-        <extracomment>The name of the StateType ({cfaa5533-d26e-4545-9f44-6567c9d7888a}) of ThingClass light
+        <extracomment>The name of the StateType ({47f8506c-af7f-4928-b0ce-8c52ce4f740b}) of ThingClass smokedetector
+----------
+The name of the StateType ({cfaa5533-d26e-4545-9f44-6567c9d7888a}) of ThingClass light
 ----------
 The name of the StateType ({b2ad6f4a-c507-45c3-a951-b344603cc3fc}) of ThingClass awning
 ----------
@@ -271,28 +292,34 @@ The name of the StateType ({67594d96-47a2-4360-a1b8-79e4f22f9ed0}) of ThingClass
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="264"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="285"/>
+        <source>Smoke Detector</source>
+        <extracomment>The name of the ThingClass ({e883a8ef-1fb7-4d7f-b40b-9cbc0133e58a})</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="288"/>
         <source>Somfy</source>
         <extracomment>The name of the vendor ({4e42a22a-ccfb-4677-89e3-f7fa16bf6be0})</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="267"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="291"/>
         <source>Somfy Tahoma</source>
         <extracomment>The name of the plugin SomfyTahoma ({4e8be1c1-daa8-4e21-9e85-b2372ab1a450})</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="270"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="294"/>
         <source>State</source>
         <extracomment>The name of the StateType ({12af28f1-475e-4d05-9bbb-adbb86dcd69c}) of ThingClass garagedoor</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="273"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="276"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="279"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="282"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="297"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="300"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="303"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="306"/>
         <source>Stop</source>
         <extracomment>The name of the ActionType ({33bec73b-4d15-493a-b553-bcee32c40ee1}) of ThingClass awning
 ----------
@@ -304,25 +331,25 @@ The name of the ActionType ({cbccf714-1188-4ac9-9c91-17fe2c99acb3}) of ThingClas
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="285"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="309"/>
         <source>Tahoma Account</source>
         <extracomment>The name of the ThingClass ({fedd72b8-547d-4e4f-b73e-71344a8ba0c1})</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="288"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="312"/>
         <source>Tahoma Gateway</source>
         <extracomment>The name of the ThingClass ({6c09e0b9-f0cc-4dea-9994-9e039eff78f1})</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="291"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="315"/>
         <source>User display name</source>
         <extracomment>The name of the StateType ({75609987-be60-4932-94f6-ead791b5fa58}) of ThingClass tahoma</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="294"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="318"/>
         <source>Venetian Blind</source>
         <extracomment>The name of the ThingClass ({c7160205-d864-4194-b418-060fff60f0cb})</extracomment>
         <translation type="unfinished"></translation>

--- a/somfytahoma/translations/4e8be1c1-daa8-4e21-9e85-b2372ab1a450-en_US.ts
+++ b/somfytahoma/translations/4e8be1c1-daa8-4e21-9e85-b2372ab1a450-en_US.ts
@@ -4,66 +4,67 @@
 <context>
     <name>IntegrationPluginSomfyTahoma</name>
     <message>
-        <location filename="../integrationpluginsomfytahoma.cpp" line="44"/>
-        <source>Please enter the login credentials for Somfy Tahoma.</source>
+        <location filename="../integrationpluginsomfytahoma.cpp" line="74"/>
+        <source>Please enter the cloud login credentials for Somfy Tahoma in order to set up local access to the Gateway.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../integrationpluginsomfytahoma.cpp" line="51"/>
-        <location filename="../integrationpluginsomfytahoma.cpp" line="67"/>
+        <location filename="../integrationpluginsomfytahoma.cpp" line="82"/>
         <source>Failed to login to Somfy Tahoma.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../integrationpluginsomfytahoma.cpp" line="87"/>
+        <source>Failed to generate token.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../integrationpluginsomfytahoma.cpp" line="98"/>
+        <source>Failed to activate token.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../integrationpluginsomfytahoma.cpp" line="122"/>
+        <source>The Somfy Plugin switched to local connection. Please enable &apos;Developer Mode&apos; on somfy.com, remove the account from Nymea and re-setup the Somfy Tahoma Gateway.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../integrationpluginsomfytahoma.cpp" line="129"/>
+        <source>Failed to connect to gateway.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SomfyTahoma</name>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="144"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="147"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="150"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="93"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="96"/>
         <source>Angle</source>
         <extracomment>The name of the ParamType (ThingClass: venetianblind, ActionType: angle, ID: {079c7a80-8a1c-4fd7-b40c-6800120c70fb})
-----------
-The name of the ParamType (ThingClass: venetianblind, EventType: angle, ID: {079c7a80-8a1c-4fd7-b40c-6800120c70fb})
 ----------
 The name of the StateType ({079c7a80-8a1c-4fd7-b40c-6800120c70fb}) of ThingClass venetianblind</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="153"/>
-        <source>Angle changed</source>
-        <extracomment>The name of the EventType ({079c7a80-8a1c-4fd7-b40c-6800120c70fb}) of ThingClass venetianblind</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="156"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="99"/>
         <source>Awning</source>
         <extracomment>The name of the ThingClass ({d3a3bb40-4b2d-4bdc-989f-5254f03b4c90})</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="159"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="162"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="165"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="102"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="105"/>
         <source>Brightness</source>
         <extracomment>The name of the ParamType (ThingClass: light, ActionType: brightness, ID: {1b51ce68-1f7e-4f06-b68d-bfca2d61b353})
-----------
-The name of the ParamType (ThingClass: light, EventType: brightness, ID: {1b51ce68-1f7e-4f06-b68d-bfca2d61b353})
 ----------
 The name of the StateType ({1b51ce68-1f7e-4f06-b68d-bfca2d61b353}) of ThingClass light</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="168"/>
-        <source>Brightness changed</source>
-        <extracomment>The name of the EventType ({1b51ce68-1f7e-4f06-b68d-bfca2d61b353}) of ThingClass light</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="171"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="174"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="177"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="180"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="108"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="111"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="114"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="117"/>
         <source>Close</source>
         <extracomment>The name of the ActionType ({20cae53b-f36d-425b-b937-3e46519893a3}) of ThingClass awning
 ----------
@@ -75,80 +76,35 @@ The name of the ActionType ({baf377c6-9fba-44cf-9f14-af0101f874b5}) of ThingClas
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="183"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="186"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="189"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="192"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="195"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="198"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="201"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="204"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="207"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="210"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="213"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="216"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="219"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="222"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="120"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="123"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="126"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="129"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="132"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="135"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="138"/>
         <source>Connected</source>
-        <extracomment>The name of the ParamType (ThingClass: light, EventType: connected, ID: {fb8dcd84-70ad-4f3e-97c4-93296608e33d})
-----------
-The name of the StateType ({fb8dcd84-70ad-4f3e-97c4-93296608e33d}) of ThingClass light
-----------
-The name of the ParamType (ThingClass: awning, EventType: connected, ID: {8f972969-10dd-4954-9c8b-de56070a6668})
+        <extracomment>The name of the StateType ({fb8dcd84-70ad-4f3e-97c4-93296608e33d}) of ThingClass light
 ----------
 The name of the StateType ({8f972969-10dd-4954-9c8b-de56070a6668}) of ThingClass awning
 ----------
-The name of the ParamType (ThingClass: garagedoor, EventType: connected, ID: {5a32cbd3-bc1c-4724-ae53-9f36cb75bf84})
-----------
 The name of the StateType ({5a32cbd3-bc1c-4724-ae53-9f36cb75bf84}) of ThingClass garagedoor
-----------
-The name of the ParamType (ThingClass: venetianblind, EventType: connected, ID: {57361115-edbe-49fb-9847-408b571d3108})
 ----------
 The name of the StateType ({57361115-edbe-49fb-9847-408b571d3108}) of ThingClass venetianblind
 ----------
-The name of the ParamType (ThingClass: rollershutter, EventType: connected, ID: {7a49865d-5ea5-43be-b61f-4e454c48e87e})
-----------
 The name of the StateType ({7a49865d-5ea5-43be-b61f-4e454c48e87e}) of ThingClass rollershutter
 ----------
-The name of the ParamType (ThingClass: gateway, EventType: connected, ID: {18ba7fb7-c9e8-4c61-86b3-a8d3b825ed00})
-----------
 The name of the StateType ({18ba7fb7-c9e8-4c61-86b3-a8d3b825ed00}) of ThingClass gateway
-----------
-The name of the ParamType (ThingClass: tahoma, EventType: connected, ID: {10ebf650-a93a-4ee3-945b-fba10d4e35a5})
 ----------
 The name of the StateType ({10ebf650-a93a-4ee3-945b-fba10d4e35a5}) of ThingClass tahoma</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="225"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="228"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="231"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="234"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="237"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="240"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="243"/>
-        <source>Connetion state changed</source>
-        <extracomment>The name of the EventType ({fb8dcd84-70ad-4f3e-97c4-93296608e33d}) of ThingClass light
-----------
-The name of the EventType ({8f972969-10dd-4954-9c8b-de56070a6668}) of ThingClass awning
-----------
-The name of the EventType ({5a32cbd3-bc1c-4724-ae53-9f36cb75bf84}) of ThingClass garagedoor
-----------
-The name of the EventType ({57361115-edbe-49fb-9847-408b571d3108}) of ThingClass venetianblind
-----------
-The name of the EventType ({7a49865d-5ea5-43be-b61f-4e454c48e87e}) of ThingClass rollershutter
-----------
-The name of the EventType ({18ba7fb7-c9e8-4c61-86b3-a8d3b825ed00}) of ThingClass gateway
-----------
-The name of the EventType ({10ebf650-a93a-4ee3-945b-fba10d4e35a5}) of ThingClass tahoma</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="246"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="249"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="252"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="255"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="258"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="141"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="144"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="147"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="150"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="153"/>
         <source>Device URL</source>
         <extracomment>The name of the ParamType (ThingClass: light, Type: thing, ID: {9cd2e0f2-a02f-478a-9358-6ff0f5aba9f5})
 ----------
@@ -162,85 +118,49 @@ The name of the ParamType (ThingClass: rollershutter, Type: thing, ID: {b3d20d6a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="261"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="156"/>
         <source>Garage Door</source>
         <extracomment>The name of the ThingClass ({cb206d74-b13c-4466-98c6-070b19ebd23a})</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="264"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="159"/>
         <source>Gateway Id</source>
         <extracomment>The name of the ParamType (ThingClass: gateway, Type: thing, ID: {e321a7d6-6dcb-4a37-baf1-c7008f2d5bdb})</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="267"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="165"/>
         <source>Light</source>
         <extracomment>The name of the ThingClass ({e569a3cc-6e79-4e24-af35-c5fa327a7314})</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="270"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="273"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="168"/>
         <source>Logged in</source>
-        <extracomment>The name of the ParamType (ThingClass: tahoma, EventType: loggedIn, ID: {97fefa85-db79-4efd-8d83-4a15d72996e1})
-----------
-The name of the StateType ({97fefa85-db79-4efd-8d83-4a15d72996e1}) of ThingClass tahoma</extracomment>
+        <extracomment>The name of the StateType ({97fefa85-db79-4efd-8d83-4a15d72996e1}) of ThingClass tahoma</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="276"/>
-        <source>Login state changed</source>
-        <extracomment>The name of the EventType ({97fefa85-db79-4efd-8d83-4a15d72996e1}) of ThingClass tahoma</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="279"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="282"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="285"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="288"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="291"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="294"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="297"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="300"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="171"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="174"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="177"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="180"/>
         <source>Moving</source>
-        <extracomment>The name of the ParamType (ThingClass: awning, EventType: moving, ID: {2507ac5a-9658-42cb-80f6-73f673c32771})
-----------
-The name of the StateType ({2507ac5a-9658-42cb-80f6-73f673c32771}) of ThingClass awning
-----------
-The name of the ParamType (ThingClass: garagedoor, EventType: moving, ID: {07175175-f95d-4cd9-a398-9aab8232c2a9})
+        <extracomment>The name of the StateType ({2507ac5a-9658-42cb-80f6-73f673c32771}) of ThingClass awning
 ----------
 The name of the StateType ({07175175-f95d-4cd9-a398-9aab8232c2a9}) of ThingClass garagedoor
 ----------
-The name of the ParamType (ThingClass: venetianblind, EventType: moving, ID: {48d5de0a-11ab-4801-94e4-a1dd458c341d})
-----------
 The name of the StateType ({48d5de0a-11ab-4801-94e4-a1dd458c341d}) of ThingClass venetianblind
-----------
-The name of the ParamType (ThingClass: rollershutter, EventType: moving, ID: {fa9446ba-da30-4d49-8fb6-f410ecc7dba0})
 ----------
 The name of the StateType ({fa9446ba-da30-4d49-8fb6-f410ecc7dba0}) of ThingClass rollershutter</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="303"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="306"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="309"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="312"/>
-        <source>Moving changed</source>
-        <extracomment>The name of the EventType ({2507ac5a-9658-42cb-80f6-73f673c32771}) of ThingClass awning
-----------
-The name of the EventType ({07175175-f95d-4cd9-a398-9aab8232c2a9}) of ThingClass garagedoor
-----------
-The name of the EventType ({48d5de0a-11ab-4801-94e4-a1dd458c341d}) of ThingClass venetianblind
-----------
-The name of the EventType ({fa9446ba-da30-4d49-8fb6-f410ecc7dba0}) of ThingClass rollershutter</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="315"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="318"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="321"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="324"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="183"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="186"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="189"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="192"/>
         <source>Open</source>
         <extracomment>The name of the ActionType ({9612954c-02cb-4159-9a29-f36eaf1c7f6a}) of ThingClass awning
 ----------
@@ -252,100 +172,70 @@ The name of the ActionType ({a0460180-e799-4bc6-83ba-11731ef124a3}) of ThingClas
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="327"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="330"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="333"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="336"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="339"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="342"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="345"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="348"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="351"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="354"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="357"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="360"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="195"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="198"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="201"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="204"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="207"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="210"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="213"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="216"/>
         <source>Percentage</source>
         <extracomment>The name of the ParamType (ThingClass: awning, ActionType: percentage, ID: {c409cb9b-82ef-4f59-ae89-eb783d4ebe97})
-----------
-The name of the ParamType (ThingClass: awning, EventType: percentage, ID: {c409cb9b-82ef-4f59-ae89-eb783d4ebe97})
 ----------
 The name of the StateType ({c409cb9b-82ef-4f59-ae89-eb783d4ebe97}) of ThingClass awning
 ----------
 The name of the ParamType (ThingClass: garagedoor, ActionType: percentage, ID: {284816aa-842b-4a86-bb4e-ef5353b76762})
 ----------
-The name of the ParamType (ThingClass: garagedoor, EventType: percentage, ID: {284816aa-842b-4a86-bb4e-ef5353b76762})
-----------
 The name of the StateType ({284816aa-842b-4a86-bb4e-ef5353b76762}) of ThingClass garagedoor
 ----------
 The name of the ParamType (ThingClass: venetianblind, ActionType: percentage, ID: {77ca50db-42a7-4434-83e2-8b5fc4438924})
-----------
-The name of the ParamType (ThingClass: venetianblind, EventType: percentage, ID: {77ca50db-42a7-4434-83e2-8b5fc4438924})
 ----------
 The name of the StateType ({77ca50db-42a7-4434-83e2-8b5fc4438924}) of ThingClass venetianblind
 ----------
 The name of the ParamType (ThingClass: rollershutter, ActionType: percentage, ID: {f954ffc7-a6aa-4d30-aee0-0484631c3344})
 ----------
-The name of the ParamType (ThingClass: rollershutter, EventType: percentage, ID: {f954ffc7-a6aa-4d30-aee0-0484631c3344})
-----------
 The name of the StateType ({f954ffc7-a6aa-4d30-aee0-0484631c3344}) of ThingClass rollershutter</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="363"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="366"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="369"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="372"/>
-        <source>Percentage changed</source>
-        <extracomment>The name of the EventType ({c409cb9b-82ef-4f59-ae89-eb783d4ebe97}) of ThingClass awning
-----------
-The name of the EventType ({284816aa-842b-4a86-bb4e-ef5353b76762}) of ThingClass garagedoor
-----------
-The name of the EventType ({77ca50db-42a7-4434-83e2-8b5fc4438924}) of ThingClass venetianblind
-----------
-The name of the EventType ({f954ffc7-a6aa-4d30-aee0-0484631c3344}) of ThingClass rollershutter</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="375"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="378"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="381"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="219"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="222"/>
         <source>Power</source>
         <extracomment>The name of the ParamType (ThingClass: light, ActionType: power, ID: {654ddcdf-b0b7-4c38-a70d-878f0f3857a5})
-----------
-The name of the ParamType (ThingClass: light, EventType: power, ID: {654ddcdf-b0b7-4c38-a70d-878f0f3857a5})
 ----------
 The name of the StateType ({654ddcdf-b0b7-4c38-a70d-878f0f3857a5}) of ThingClass light</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="384"/>
-        <source>Power changed</source>
-        <extracomment>The name of the EventType ({654ddcdf-b0b7-4c38-a70d-878f0f3857a5}) of ThingClass light</extracomment>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="162"/>
+        <source>Gateway pin</source>
+        <extracomment>The name of the ParamType (ThingClass: gateway, Type: thing, ID: {30b73244-e5bb-4c00-9332-702a60c03420})</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="387"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="225"/>
         <source>Roller Shutter</source>
         <extracomment>The name of the ThingClass ({6b187fe0-a987-462d-90ac-c48efc0d0fc0})</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="390"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="228"/>
         <source>Set angle</source>
         <extracomment>The name of the ActionType ({079c7a80-8a1c-4fd7-b40c-6800120c70fb}) of ThingClass venetianblind</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="393"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="231"/>
         <source>Set brightness</source>
         <extracomment>The name of the ActionType ({1b51ce68-1f7e-4f06-b68d-bfca2d61b353}) of ThingClass light</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="396"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="399"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="402"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="405"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="234"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="237"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="240"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="243"/>
         <source>Set percentage</source>
         <extracomment>The name of the ActionType ({c409cb9b-82ef-4f59-ae89-eb783d4ebe97}) of ThingClass awning
 ----------
@@ -357,94 +247,52 @@ The name of the ActionType ({f954ffc7-a6aa-4d30-aee0-0484631c3344}) of ThingClas
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="408"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="246"/>
         <source>Set power</source>
         <extracomment>The name of the ActionType ({654ddcdf-b0b7-4c38-a70d-878f0f3857a5}) of ThingClass light</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="411"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="414"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="417"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="420"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="423"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="426"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="429"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="432"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="435"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="438"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="249"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="252"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="255"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="258"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="261"/>
         <source>Signal strength</source>
-        <extracomment>The name of the ParamType (ThingClass: light, EventType: signalStrength, ID: {cfaa5533-d26e-4545-9f44-6567c9d7888a})
-----------
-The name of the StateType ({cfaa5533-d26e-4545-9f44-6567c9d7888a}) of ThingClass light
-----------
-The name of the ParamType (ThingClass: awning, EventType: signalStrength, ID: {b2ad6f4a-c507-45c3-a951-b344603cc3fc})
+        <extracomment>The name of the StateType ({cfaa5533-d26e-4545-9f44-6567c9d7888a}) of ThingClass light
 ----------
 The name of the StateType ({b2ad6f4a-c507-45c3-a951-b344603cc3fc}) of ThingClass awning
 ----------
-The name of the ParamType (ThingClass: garagedoor, EventType: signalStrength, ID: {0a194091-3073-4912-9d84-f1d52c8534bd})
-----------
 The name of the StateType ({0a194091-3073-4912-9d84-f1d52c8534bd}) of ThingClass garagedoor
 ----------
-The name of the ParamType (ThingClass: venetianblind, EventType: signalStrength, ID: {aee4f4e3-3445-441d-bdbb-631b0c5db942})
-----------
 The name of the StateType ({aee4f4e3-3445-441d-bdbb-631b0c5db942}) of ThingClass venetianblind
-----------
-The name of the ParamType (ThingClass: rollershutter, EventType: signalStrength, ID: {67594d96-47a2-4360-a1b8-79e4f22f9ed0})
 ----------
 The name of the StateType ({67594d96-47a2-4360-a1b8-79e4f22f9ed0}) of ThingClass rollershutter</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="441"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="444"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="447"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="450"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="453"/>
-        <source>Signal strength changed</source>
-        <extracomment>The name of the EventType ({cfaa5533-d26e-4545-9f44-6567c9d7888a}) of ThingClass light
-----------
-The name of the EventType ({b2ad6f4a-c507-45c3-a951-b344603cc3fc}) of ThingClass awning
-----------
-The name of the EventType ({0a194091-3073-4912-9d84-f1d52c8534bd}) of ThingClass garagedoor
-----------
-The name of the EventType ({aee4f4e3-3445-441d-bdbb-631b0c5db942}) of ThingClass venetianblind
-----------
-The name of the EventType ({67594d96-47a2-4360-a1b8-79e4f22f9ed0}) of ThingClass rollershutter</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="456"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="264"/>
         <source>Somfy</source>
         <extracomment>The name of the vendor ({4e42a22a-ccfb-4677-89e3-f7fa16bf6be0})</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="459"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="267"/>
         <source>Somfy Tahoma</source>
         <extracomment>The name of the plugin SomfyTahoma ({4e8be1c1-daa8-4e21-9e85-b2372ab1a450})</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="462"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="465"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="270"/>
         <source>State</source>
-        <extracomment>The name of the ParamType (ThingClass: garagedoor, EventType: state, ID: {12af28f1-475e-4d05-9bbb-adbb86dcd69c})
-----------
-The name of the StateType ({12af28f1-475e-4d05-9bbb-adbb86dcd69c}) of ThingClass garagedoor</extracomment>
+        <extracomment>The name of the StateType ({12af28f1-475e-4d05-9bbb-adbb86dcd69c}) of ThingClass garagedoor</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="468"/>
-        <source>State changed</source>
-        <extracomment>The name of the EventType ({12af28f1-475e-4d05-9bbb-adbb86dcd69c}) of ThingClass garagedoor</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="471"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="474"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="477"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="480"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="273"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="276"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="279"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="282"/>
         <source>Stop</source>
         <extracomment>The name of the ActionType ({33bec73b-4d15-493a-b553-bcee32c40ee1}) of ThingClass awning
 ----------
@@ -456,34 +304,25 @@ The name of the ActionType ({cbccf714-1188-4ac9-9c91-17fe2c99acb3}) of ThingClas
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="483"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="285"/>
         <source>Tahoma Account</source>
         <extracomment>The name of the ThingClass ({fedd72b8-547d-4e4f-b73e-71344a8ba0c1})</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="486"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="288"/>
         <source>Tahoma Gateway</source>
         <extracomment>The name of the ThingClass ({6c09e0b9-f0cc-4dea-9994-9e039eff78f1})</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="489"/>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="492"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="291"/>
         <source>User display name</source>
-        <extracomment>The name of the ParamType (ThingClass: tahoma, EventType: userDisplayName, ID: {75609987-be60-4932-94f6-ead791b5fa58})
-----------
-The name of the StateType ({75609987-be60-4932-94f6-ead791b5fa58}) of ThingClass tahoma</extracomment>
+        <extracomment>The name of the StateType ({75609987-be60-4932-94f6-ead791b5fa58}) of ThingClass tahoma</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="495"/>
-        <source>User display name changed</source>
-        <extracomment>The name of the EventType ({75609987-be60-4932-94f6-ead791b5fa58}) of ThingClass tahoma</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../build/somfytahoma/plugininfo.h" line="498"/>
+        <location filename="../../build/somfytahoma/plugininfo.h" line="294"/>
         <source>Venetian Blind</source>
         <extracomment>The name of the ThingClass ({c7160205-d864-4194-b418-060fff60f0cb})</extracomment>
         <translation type="unfinished"></translation>


### PR DESCRIPTION
This PR changes the somfytahoma plugin to directly connect to Somfy Tahoma Gateways without having to rely on the Somfy Tahoma cloud connection.

In order to activate this local API, users need to enable the so called 'Developer Mode' on their gateways. See https://developer.somfy.com/developer-mode. Existing plugin users will have to reconfigure the plugin.

The old cloud based access had several disadvantages:
- Somfy changed the login method that caused the old version of the plugin to disconnect after a few days.
- Somfy started to disconnect and block 3rd party applications that polled device updates too fast.

The local access now offers various advantages:
- We don't rely on an internet connection any more (except for initial access to the box) which should drastically improve stability and performance of the integration.
- The 'Developer Mode' is officially supported, documented and officially grants access for 3rd Party applications. See https://github.com/Somfy-Developer/Somfy-TaHoma-Developer-Mode.

Additional changes in this PR:
- Add support for Smoke Detector.

---
Known Issues:

- [ ] Event polling started to fail after a couple of days, but there's no usable debug output. I've improved the error logging now.
- [ ] Access tokens are valid only for 6 months. Need to add logic to refresh the token.

Fixed Issues:

- [x] Unregistering the token on removal of the gateway fails. Need to investigate how the API is meant to be used.
- [x] Plugin never uses the IP it gets through Zeroconf. This was caused by an incorrect filter.

---

- [x] Make sure the pull request's title is of format "Plugin name: Add support for xyz" or "New plugin: Plugin name"
- [x] Did you test the changes on hardware, if not (e.g. absence of required hardware), please mention a person to confirm it has been tested.
- [x] Did you update the plugin's README.md accordingly?
- [x] Did you update translations (`cd builddir && make lupdate`)?
