### PR TITLE
somfytahoma: Fix actions for roller shutters

### DIFF
--- a/somfytahoma/integrationpluginsomfytahoma.cpp
+++ b/somfytahoma/integrationpluginsomfytahoma.cpp
@@ -549,14 +549,12 @@ void IntegrationPluginSomfyTahoma::executeAction(ThingActionInfo *info)
     if (info->thing()->thingClassId() == rollershutterThingClassId) {
         deviceUrl = info->thing()->paramValue(rollershutterThingDeviceUrlParamTypeId).toString();
         if (info->action().actionTypeId() == rollershutterPercentageActionTypeId) {
-            actionName = "setClosureAndLinearSpeed";
-            actionParameters = { info->action().param(rollershutterPercentageActionPercentageParamTypeId).value().toInt(), "lowspeed" };
+            actionName = "setClosure";
+            actionParameters = { info->action().param(rollershutterPercentageActionPercentageParamTypeId).value().toInt() };
         } else if (info->action().actionTypeId() == rollershutterOpenActionTypeId) {
-            actionName = "setClosureAndLinearSpeed";
-            actionParameters = { 0, "lowspeed" };
+            actionName = "open";
         } else if (info->action().actionTypeId() == rollershutterCloseActionTypeId) {
-            actionName = "setClosureAndLinearSpeed";
-            actionParameters = { 100, "lowspeed" };
+            actionName = "close";
         } else if (info->action().actionTypeId() == rollershutterStopActionTypeId) {
             actionName = "stop";
         }


### PR DESCRIPTION
The assumption that all IO roller shutters support the
setClosureAndLinearSpeed action was incorrect, only the RS100 IO does.

In order to maximize compatibility, use setClosure instead.

For the moment this means RS100 IO motors don't move in silent mode
anymore until we find a solution to differentiate them from others.

Forum reference: https://forum.nymea.io/t/somfytahoma-plugin-questions/814/9

---

nymea-plugins pull request checklist:

- [x] Make sure the pull request's title is of format "Plugin name: Add support for xyz" or "New plugin: Plugin name"

- [x] Did you test the changes on hardware, if not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [x] ~Did you update the plugin's README.md accordingly?~

- [x] ~Did you update translations (`cd builddir && make lupdate`)?~
