### PR TITLE
AQI: Reorder interfaces based on their relevancy

### DIFF
--- a/aqi/integrationpluginaqi.json
+++ b/aqi/integrationpluginaqi.json
@@ -22,7 +22,7 @@
                     "id": "23ea32c9-38b0-4155-bacc-3afa8c09f6ee",
                     "name": "airQualityIndex",
                     "displayName": "Air quality index",
-                    "interfaces": ["o3sensor", "cosensor", "no2sensor", "pm10sensor", "pm25sensor", "windspeedsensor", "humiditysensor", "pressuresensor", "temperaturesensor", "connectable"],
+                    "interfaces": ["pm25sensor", "pm10sensor", "cosensor", "no2sensor", "o3sensor", "temperaturesensor", "humiditysensor", "pressuresensor", "windspeedsensor", "connectable"],
                     "createMethods": ["discovery", "user"],
                     "paramTypes": [
                         {


### PR DESCRIPTION
The ordering of the interfaces is used by the app to determine best matches for a particular use case. The AQI plugin is most likely to be relevant for use cases regarding particulate matter measurement.

nymea-plugins pull request checklist:

- [x] Make sure the pull request's title is of format "Plugin name: Add support for xyz" or "New plugin: Plugin name"

- [x] Did you test the changes on hardware, if not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [x] Did you update the plugin's README.md accordingly?

- [x] Did you update translations (`cd builddir && make lupdate`)?
