### PR TITLE
Netatmo: fix OAuth2 credentials loading from api key provider

### DIFF
--- a/netatmo/integrationpluginnetatmo.cpp
+++ b/netatmo/integrationpluginnetatmo.cpp
@@ -636,7 +636,7 @@ bool IntegrationPluginNetatmo::loadClientCredentials()
     QByteArray clientId = configValue(netatmoPluginCustomClientIdParamTypeId).toByteArray();
     QByteArray clientSecret = configValue(netatmoPluginCustomClientSecretParamTypeId).toByteArray();
     if (clientId.isEmpty() || clientSecret.isEmpty()) {
-        clientId = apiKeyStorage()->requestKey("netatmo").data("clientKey");
+        clientId = apiKeyStorage()->requestKey("netatmo").data("clientId");
         clientSecret = apiKeyStorage()->requestKey("netatmo").data("clientSecret");
     } else {
         qCDebug(dcNetatmo()) << "Using custom client  id and secret from plugin configuration.";


### PR DESCRIPTION
nymea-plugins pull request checklist:

- [x] Make sure the pull request's title is of format "Plugin name: Add support for xyz" or "New plugin: Plugin name"

- [x] Did you test the changes on hardware, if not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [x] Did you update the plugin's README.md accordingly?

- [x] Did you update translations (`cd builddir && make lupdate`)?
