### PR TITLE
Easee: Added support for easee Wallbox

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -200,6 +200,13 @@ Conflicts: nymea-plugins-translations (< 1.0.1)
 Description: nymea integration plugin for dynatrace
  This package contains the nymea integration plugin for the dynatrace UFO
 
+Package: nymea-plugin-easee
+Architecture: any
+Depends: ${shlibs:Depends},
+         ${misc:Depends},
+Conflicts: nymea-plugins-translations (< 1.0.1)
+Description: nymea integration plugin for easee
+ This package contains the nymea integration plugin for devices from Easee
 
 Package: nymea-plugin-elgato
 Architecture: any

--- a/debian/nymea-plugin-easee.install.in
+++ b/debian/nymea-plugin-easee.install.in
@@ -1,0 +1,2 @@
+usr/lib/@DEB_HOST_MULTIARCH@/nymea/plugins/libnymea_integrationplugineasee.so
+easee/translations/*qm usr/share/nymea/translations/

--- a/easee/README.md
+++ b/easee/README.md
@@ -1,0 +1,4 @@
+# easee
+--------------------------------
+
+Description of the plugin...

--- a/easee/README.md
+++ b/easee/README.md
@@ -1,4 +1,4 @@
 # easee
 --------------------------------
 
-Description of the plugin...
+This Plugin implements the Easee Wallbox. It allows connecting to the cloud Api to read and control the Wallbox.

--- a/easee/easee.pro
+++ b/easee/easee.pro
@@ -1,0 +1,10 @@
+include($$[QT_INSTALL_PREFIX]/include/nymea/plugin.pri)
+
+SOURCES += \
+    integrationplugineasee.cpp
+
+HEADERS += \
+    integrationplugineasee.h
+QT += \
+    network
+

--- a/easee/integrationplugineasee.cpp
+++ b/easee/integrationplugineasee.cpp
@@ -1,0 +1,279 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *                                                                         *
+ *  Copyright (C) 2020 Tim Stöcker <t.stoecker@consolinno.de>                 *
+ *                                                                         *
+ *  This library is free software; you can redistribute it and/or          *
+ *  modify it under the terms of the GNU Lesser General Public             *
+ *  License as published by the Free Software Foundation;                  *
+ *  version 3 of the License.                                              *
+ *                                                                         *
+ *  This library is distributed in the hope that it will be useful,        *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU      *
+ *  Lesser General Public License for more details.                        *
+ *                                                                         *
+ *  You should have received a copy of the GNU Lesser General Public       *
+ *  License along with this library; If not, see                           *
+ *  <http://www.gnu.org/licenses/>.                                        *
+ *                                                                         *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "plugininfo.h"
+#include "integrationplugineasee.h"
+
+
+#include <network/networkaccessmanager.h>
+#include <plugintimer.h>
+#include <QtNetwork>
+#include <QNetworkReply>
+#include <QJsonDocument>
+#include <QTimer>
+#include <QNetworkAccessManager>
+
+IntegrationPluginEasee::IntegrationPluginEasee()
+{
+
+}
+
+void IntegrationPluginEasee::init()
+{
+    // Initialisation can be done here.
+    qCDebug(dcEasee()) << "Plugin initialized.";
+}
+
+void IntegrationPluginEasee::startPairing(ThingPairingInfo *info)
+{
+    info->finish(Thing::ThingErrorNoError, QT_TR_NOOP("Please enter your login credentials for the Easee Wallbox."));
+}
+
+void IntegrationPluginEasee::confirmPairing(ThingPairingInfo *info, const QString &username, const QString &secret)
+{
+    QString chargerId = info->params().paramValue(wallboxThingChargerIdParamTypeId).toString();
+    QNetworkRequest header = composeApiKeyRequest();
+    QJsonObject param;
+    param.insert("username", QJsonValue::fromVariant(username));
+    param.insert("password", QJsonValue::fromVariant(secret));
+    pluginStorage()->beginGroup(chargerId);
+    pluginStorage()->setValue("username", username);
+    pluginStorage()->setValue("password", secret);
+    pluginStorage()->endGroup();
+    QNetworkReply *reply = hardwareManager()->networkManager()->post(header,QJsonDocument(param).toJson(QJsonDocument::Compact));
+    connect(reply, &QNetworkReply::finished, info, [=](){
+        info->finish(Thing::ThingErrorNoError);
+        QByteArray response_data = reply->readAll();
+        QJsonDocument json = QJsonDocument::fromJson(response_data);
+        accessKey = json.object().value("accessToken").toString();
+
+        if (QString::compare (accessKey,"") != 0){
+            info->finish(Thing::ThingErrorNoError);
+        } else {
+            info->finish(Thing::ThingErrorAuthenticationFailure);
+        }
+        reply->deleteLater();
+    });
+
+
+
+}
+
+
+void IntegrationPluginEasee::setupThing(ThingSetupInfo *info)
+{
+    // A thing is being set up. Use info->thing() to get details of the thing, do
+    // the required setup (e.g. connect to the device) and call info->finish() when done.
+
+    qCDebug(dcEasee()) << "Setup thing" << info->thing();
+    if (QString::compare (accessKey,"") != 0){
+        info->thing()->setStateValue(wallboxConnectedStateTypeId, true);
+
+    }
+    else {
+        refreshAccessToken(info->thing());
+    }
+    info->finish(Thing::ThingErrorNoError);
+
+
+}
+void IntegrationPluginEasee::postSetupThing(Thing *thing)
+{
+    Q_UNUSED(thing)
+
+    if (!m_timer) {
+        m_timer = hardwareManager()->pluginTimerManager()->registerTimer(5);
+        connect(m_timer, &PluginTimer::timeout, this, [this](){
+            foreach (Thing *thing, myThings()) {
+
+                if (QString::compare (accessKey,"") != 0 && (siteId == 0 || circuitId == 0 ) ){
+                    getSiteAndCircuit(thing);
+                } else if (QString::compare (accessKey,"") == 0) {
+                    refreshAccessToken(thing);
+                }
+                else {
+                    qCDebug(dcEasee()) << "Credentials Retrieved from the Cloud" <<siteId;
+                    getCurrentPower(thing);
+                    writeCurrentLimit(thing);
+                }
+            }
+        });
+    }
+
+    if (!access_timer){
+        access_timer = hardwareManager()->pluginTimerManager()->registerTimer(8600);
+        connect(access_timer, &PluginTimer::timeout, this, [this](){
+            foreach (Thing *thing, myThings()) {
+                refreshAccessToken(thing);
+            }
+        });
+    }
+}
+
+void IntegrationPluginEasee::refreshAccessToken(Thing *thing)
+{
+    QString chargerId = thing->paramValue(wallboxThingChargerIdParamTypeId).toString();
+    pluginStorage()->beginGroup(chargerId);
+    QString username = pluginStorage()->value("username").toString();
+    QString password = pluginStorage()->value("password").toString();
+    pluginStorage()->endGroup();
+    QNetworkRequest header = composeApiKeyRequest();
+    QJsonObject param;
+    param.insert("username", QJsonValue::fromVariant(username));
+    param.insert("password", QJsonValue::fromVariant(password));
+    QNetworkReply *reply = hardwareManager()->networkManager()->post(header,QJsonDocument(param).toJson(QJsonDocument::Compact));
+    connect(reply, &QNetworkReply::finished, thing, [=](){
+
+        QByteArray response_data = reply->readAll();
+        QJsonDocument json = QJsonDocument::fromJson(response_data);
+        accessKey = json.object().value("accessToken").toString();
+        if (QString::compare (accessKey,"") != 0){
+            thing->setStateValue(wallboxConnectedStateTypeId, true);
+
+        }
+        else {
+            thing->setStateValue(wallboxConnectedStateTypeId, false);
+        }
+        reply->deleteLater();
+    });
+
+
+}
+void IntegrationPluginEasee::getSiteAndCircuit(Thing *thing){
+    QString chargerId = thing->paramValue(wallboxThingChargerIdParamTypeId).toString();
+    QNetworkRequest header = composeSiteAndCircuitRequest(chargerId);
+    QNetworkReply *reply = hardwareManager()->networkManager()->get(header);
+    connect(reply, &QNetworkReply::finished, thing, [=](){
+        QByteArray response_data = reply->readAll();
+        QJsonDocument json = QJsonDocument::fromJson(response_data);
+        QJsonArray subJson = json.object().value("circuits").toArray();
+        QJsonDocument siteJson = QJsonDocument::fromVariant(subJson.at(0).toVariant());
+        double site = siteJson.object().value("siteId").toDouble();
+        double circuit =siteJson.object().value("id").toDouble();
+        siteId = site;
+        circuitId = circuit;
+
+    });
+    reply->deleteLater();
+
+}
+
+void IntegrationPluginEasee::getCurrentPower(Thing *thing){
+    QString chargerId = thing->paramValue(wallboxThingChargerIdParamTypeId).toString();
+    QNetworkRequest header = composeCurrentPowerRequest(chargerId);
+    QNetworkReply *reply = hardwareManager()->networkManager()->get(header);
+    connect(reply, &QNetworkReply::finished, thing, [=](){
+        QByteArray response_data = reply->readAll();
+        QJsonDocument json = QJsonDocument::fromJson(response_data);
+        double totalPower = json.object().value("totalPower").toDouble();
+        double phaseMode = json.object().value("outputPhase").toDouble();
+        if (phaseMode > 10) {thing->setStateValue(wallboxPhaseCountStateTypeId,3);}
+        else {thing->setStateValue(wallboxPhaseCountStateTypeId,1);}
+        thing->setStateValue(wallboxCurrentPowerStateTypeId,totalPower);
+        qCDebug(dcEasee()) << json.object().value("dynamicChargerCurrent").toDouble();
+        qCDebug(dcEasee()) << phaseMode;
+        if (totalPower > 10){
+            thing->setStateValue(wallboxPluggedInStateTypeId,true);
+            thing->setStateValue(wallboxChargingStateTypeId,true);
+
+        } else {
+            thing->setStateValue(wallboxPluggedInStateTypeId,false);
+            thing->setStateValue(wallboxChargingStateTypeId,false);
+        }
+        if (reply->error() != QNetworkReply::NetworkError::NoError){
+            thing->setStateValue(wallboxConnectedStateTypeId, false);
+        }
+        reply->deleteLater();
+    });
+
+}
+
+void IntegrationPluginEasee::writeCurrentLimit(Thing *thing)
+{
+    QNetworkRequest header = composeCurrentLimitRequest();
+    int limit = thing->state("maxChargingCurrent").value().toInt();
+    QJsonObject param;
+    param.insert("phase1", QJsonValue::fromVariant(limit));
+    param.insert("phase2", QJsonValue::fromVariant(limit));
+    param.insert("phase3", QJsonValue::fromVariant(limit));
+    param.insert("timeToLive", QJsonValue::fromVariant(1));
+    QNetworkReply *reply = hardwareManager()->networkManager()->post(header,QJsonDocument(param).toJson(QJsonDocument::Compact));
+    connect(reply, &QNetworkReply::finished, thing, [=](){
+        if (reply->error() != QNetworkReply::NetworkError::NoError){
+            thing->setStateValue(wallboxConnectedStateTypeId, false);
+        }
+        reply->deleteLater();
+    });
+
+
+}
+
+void IntegrationPluginEasee::executeAction(ThingActionInfo *info)
+{
+    // An action is being executed. Use info->action() to get details about the action,
+    // do the required operations (e.g. send a command to the network) and call info->finish() when done.
+
+    qCDebug(dcEasee()) << "Executing action for thing" << info->thing() << info->action().actionTypeId().toString() << info->action().params();
+
+    info->finish(Thing::ThingErrorNoError);
+}
+
+void IntegrationPluginEasee::thingRemoved(Thing *thing)
+{
+    // A thing is being removed from the system. Do the required cleanup
+    // (e.g. disconnect from the device) here.
+    delete m_timer;
+    delete access_timer;
+    qCDebug(dcEasee()) << "Remove thing" << thing;
+}
+QNetworkRequest IntegrationPluginEasee::composeApiKeyRequest()
+{
+    QUrl url("https://api.easee.cloud/api/accounts/login");
+    QNetworkRequest request(url);
+    request.setHeader(QNetworkRequest::ContentTypeHeader, "application/*+json");
+    return request;
+}
+
+QNetworkRequest IntegrationPluginEasee::composeSiteAndCircuitRequest(const QString &chargerId)
+{
+    QUrl url("https://api.easee.cloud/api/chargers/"+ chargerId +"/site");
+    QNetworkRequest request(url);
+    QString headerData = "Bearer " + accessKey;
+    request.setRawHeader("Authorization", headerData.toLocal8Bit());
+    return request;
+}
+
+QNetworkRequest IntegrationPluginEasee::composeCurrentPowerRequest(const QString &chargerId)
+{
+    QUrl url("https://api.easee.cloud/api/chargers/"+ chargerId +"/state");
+    QNetworkRequest request(url);
+    QString headerData = "Bearer " + accessKey;
+    request.setRawHeader("Authorization", headerData.toLocal8Bit());
+    return request;
+}
+QNetworkRequest IntegrationPluginEasee::composeCurrentLimitRequest()
+{
+    QUrl url("https://api.easee.cloud/api/sites/"+ QString::number((int)siteId,10) +"/circuits/" +  QString::number((int)circuitId,10) +"/dynamicCurrent");
+    QNetworkRequest request(url);
+    qCDebug(dcEasee()) << url;
+    QString headerData = "Bearer " + accessKey;
+    request.setRawHeader("Authorization", headerData.toLocal8Bit());
+    return request;
+}

--- a/easee/integrationplugineasee.h
+++ b/easee/integrationplugineasee.h
@@ -1,0 +1,74 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *                                                                         *
+ *  Copyright (C) 2022 Tim Stöcker <t.stoecker@consolinno.de>                 *
+ *                                                                         *
+ *  This library is free software; you can redistribute it and/or          *
+ *  modify it under the terms of the GNU Lesser General Public             *
+ *  License as published by the Free Software Foundation;                  *
+ *  version 3 of the License.                                              *
+ *                                                                         *
+ *  This library is distributed in the hope that it will be useful,        *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU      *
+ *  Lesser General Public License for more details.                        *
+ *                                                                         *
+ *  You should have received a copy of the GNU Lesser General Public       *
+ *  License along with this library; If not, see                           *
+ *  <http://www.gnu.org/licenses/>.                                        *
+ *                                                                         *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef INTEGRATIONPLUGINEASEE_H
+#define INTEGRATIONPLUGINEASEE_H
+
+#include "integrations/integrationplugin.h"
+#include <QString>
+class PluginTimer;
+#include <QNetworkRequest>
+
+class IntegrationPluginEasee: public IntegrationPlugin
+{
+    Q_OBJECT
+
+    Q_PLUGIN_METADATA(IID "io.nymea.IntegrationPlugin" FILE "integrationplugineasee.json")
+    Q_INTERFACES(IntegrationPlugin)
+
+
+public:
+    explicit IntegrationPluginEasee();
+
+    void init() override;
+
+    void startPairing(ThingPairingInfo *info) override;
+
+    void confirmPairing(ThingPairingInfo *info, const QString &username, const QString &secret) override;
+
+    void setupThing(ThingSetupInfo *info) override;
+
+    void postSetupThing(Thing *thing) override;
+
+    void executeAction(ThingActionInfo *info) override;
+
+    void thingRemoved(Thing *thing) override;
+
+
+private slots:
+    void refreshAccessToken(Thing *thing);
+    void getSiteAndCircuit(Thing *thing);
+    void getCurrentPower(Thing *thing);
+    void writeCurrentLimit(Thing *thing);
+
+
+private:
+    QNetworkRequest composeApiKeyRequest();
+    QNetworkRequest composeSiteAndCircuitRequest(const QString &chargerId);
+    QNetworkRequest composeCurrentPowerRequest(const QString &chargerId);
+    QNetworkRequest composeCurrentLimitRequest();
+    QString accessKey;
+    PluginTimer *m_timer = nullptr;
+    PluginTimer *access_timer = nullptr;
+    double siteId = 0;
+    double circuitId = 0;
+};
+
+#endif // INTEGRATIONPLUGINEASEE_H

--- a/easee/integrationplugineasee.json
+++ b/easee/integrationplugineasee.json
@@ -1,0 +1,136 @@
+{
+    "name": "easee",
+    "displayName": "Easee",
+    "id": "da7e8f41-ce86-408c-932e-5ce4cc00df8c",
+    "vendors": [
+        {
+            "name": "easee",
+            "displayName": "Easee",
+            "id": "8f676c8a-22a4-430c-90b3-7250fc2e5cd3",
+            "thingClasses": [
+                {
+                    "name": "wallbox",
+                    "displayName": "Easee Home Wallbox",
+                    "id": "651fce83-682f-4957-a9f2-778e07ed59ae",
+                    "setupMethod": "userandpassword",
+                    "createMethods": ["User"],
+                    "interfaces": [ "evcharger", "smartmeterconsumer","connectable"],
+                    "paramTypes": [
+                    {
+
+                    "id": "2ca038e4-8b09-42c4-a0c6-555fa65d0d45",
+                    "name": "chargerId",
+                    "displayName": "Charger ID",
+                    "type": "QString",
+                    "inputType": "TextLine",
+                    "defaultValue":""
+                    }
+
+                    ],
+                    "stateTypes": [
+                    {
+                        "id": "7fecdb0e-3fa5-4d9a-acc6-249eb7b01b30",
+                        "name": "maxChargingCurrent",
+                        "displayName": "Maximal charging current",
+                        "displayNameEvent": "Maximal charging current changed",
+                        "displayNameAction": "Set maximal charging current",
+                        "type": "uint",
+                        "unit": "Ampere",
+                        "defaultValue": 6,
+                        "minValue": 6,
+                        "maxValue": 32,
+                        "writable": true,
+                        "suggestLogging": true
+                    },
+                    {
+                        "id": "1b72caef-8f95-4f90-8bb0-ef77d00892c8",
+                        "name": "pluggedIn",
+                        "displayName": "Car plugged in",
+                        "displayNameEvent": "Car plugged in changed",
+                        "type": "bool",
+                        "defaultValue": false
+                    },
+                    {
+                        "id": "2009b3e6-66fb-4563-9dad-3c9c6dbdb0f3",
+                        "name": "charging",
+                        "displayName": "Charging",
+                        "displayNameEvent": "Charging changed",
+                        "type": "bool",
+                        "defaultValue": false
+                    },
+                    {
+                        "id": "e6f6bffa-14f2-4485-b0a0-de73d5aa5c1a",
+                        "name": "phaseCount",
+                        "displayName": "Number of connected phases",
+                        "displayNameEvent": "Number of connected phases changed",
+                        "type": "uint",
+                        "minValue": 1,
+                        "maxValue": 3,
+                        "defaultValue": 1
+                    },
+                    {
+                        "id": "e812dc3f-46cf-4c9a-b54e-8d629ef5a553",
+                        "name": "sessionEnergy",
+                        "displayName": "Session energy",
+                        "displayNameEvent": "Session energy changed",
+                        "type": "double",
+                        "unit": "KiloWattHour",
+                        "defaultValue": 0,
+                        "suggestLogging": true
+                    },
+                    {
+                        "id": "e348f99c-1e65-4d47-ac1c-8327be970dc3",
+                        "name": "connected",
+                        "displayName": "Connected",
+                        "displayNameEvent": "Connected changed",
+                        "type": "bool",
+                        "defaultValue": false,
+                        "cached": false
+                    },
+                    {
+                         "id": "0316a57e-0d73-4fe6-9873-0e0f73fbff70",
+                         "name": "totalEnergyConsumed",
+                         "displayName": "Total energy consumed",
+                         "displayNameEvent": "Total energy consumption changed",
+                         "type": "double",
+                         "unit": "KiloWattHour",
+                         "defaultValue": 0,
+                         "suggestLogging": true
+                     },
+                     {
+                         "id": "50099a93-ee7b-4c86-b739-33f611cba7a0",
+                         "name": "currentPower",
+                         "displayName": "Power consumption",
+                         "displayNameEvent": "Power consumtion changed",
+                         "type": "double",
+                         "unit": "Watt",
+                         "defaultValue": 0.00,
+                         "suggestLogging": true
+                      },
+                      {
+                         "id": "25b2b46c-90c8-412a-ae62-c8ff6caa4be1",
+                         "name": "power",
+                         "displayName": "Charging enabled",
+                         "displayNameEvent": "Charging enabled changed",
+                         "displayNameAction": "Set charging enabled",
+                         "type": "bool",
+                         "writable": true,
+                         "defaultValue": false,
+                         "suggestLogging": true
+                       }
+
+                    ],
+                    "actionTypes": [
+
+                    ],
+                    "eventTypes": [
+
+                    ]
+                }
+            ]
+        }
+    ]
+}
+
+
+

--- a/easee/translations/da7e8f41-ce86-408c-932e-5ce4cc00df8c-en_US.ts
+++ b/easee/translations/da7e8f41-ce86-408c-932e-5ce4cc00df8c-en_US.ts
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>IntegrationPluginEasee</name>
+    <message>
+        <location filename="../integrationplugineasee.cpp" line="46"/>
+        <source>Please enter your login credentials for the Easee Wallbox.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/nymea-plugins.pro
+++ b/nymea-plugins.pro
@@ -19,6 +19,7 @@ PLUGIN_DIRS = \
     dht                 \
     dweetio             \
     dynatrace           \
+    easee               \
     elgato              \
     eq-3                \
     espuino             \


### PR DESCRIPTION
This plugin Implements the Easse Wallbox using the proprietary Cloud Api. 
At the moment this Plugin is designed to only use one Wallbox per cluster, because a cluster has to be controlled differently. Our usecase however does not include this.


nymea-plugins pull request checklist:

- [✓] Make sure the pull request's title is of format "Plugin name: Add support for xyz" or "New plugin: Plugin name"

- [✓] Did you test the changes on hardware, if not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [✓] Did you update the plugin's README.md accordingly?

- [✓] Did you update translations (`cd builddir && make lupdate`)?
