### PR TITLE
EQ-3, Tado: Update thermostats windowOpenDetected states

### DIFF
--- a/eq-3/integrationplugineq-3.cpp
+++ b/eq-3/integrationplugineq-3.cpp
@@ -66,7 +66,7 @@ void IntegrationPluginEQ3::discoverThings(ThingDiscoveryInfo *info)
 
         connect(info, &QObject::destroyed, cubeDiscovery, &MaxCubeDiscovery::deleteLater);
 
-        connect(cubeDiscovery, &MaxCubeDiscovery::cubesDetected, info, [this, info, cubeDiscovery](const QList<MaxCubeDiscovery::CubeInfo> &cubeList){
+        connect(cubeDiscovery, &MaxCubeDiscovery::cubesDetected, info, [this, info](const QList<MaxCubeDiscovery::CubeInfo> &cubeList){
 
             foreach (const MaxCubeDiscovery::CubeInfo &cube, cubeList) {
                 ThingDescriptor descriptor(cubeThingClassId, "Max! Cube LAN Gateway", cube.serialNumber);
@@ -200,9 +200,9 @@ void IntegrationPluginEQ3::setupThing(ThingSetupInfo *info)
             thing->setStateValue(eqivaBluetoothTargetTemperatureStateTypeId, eqivaDevice->targetTemperature());
         });
         // Window open state
-        thing->setStateValue(eqivaBluetoothWindowOpenStateTypeId, eqivaDevice->windowOpen());
+        thing->setStateValue(eqivaBluetoothWindowOpenDetectedStateTypeId, eqivaDevice->windowOpen());
         connect(eqivaDevice, &EqivaBluetooth::windowOpenChanged, thing, [thing, eqivaDevice](){
-            thing->setStateValue(eqivaBluetoothWindowOpenStateTypeId, eqivaDevice->windowOpen());
+            thing->setStateValue(eqivaBluetoothWindowOpenDetectedStateTypeId, eqivaDevice->windowOpen());
         });
         // Valve open state
         thing->setStateValue(eqivaBluetoothValveOpenStateTypeId, eqivaDevice->valveOpen());

--- a/eq-3/integrationplugineq-3.json
+++ b/eq-3/integrationplugineq-3.json
@@ -611,9 +611,8 @@
                         },
                         {
                             "id": "dcacdacc-ee47-43b0-9fef-1fe423e4f355",
-                            "name": "windowOpen",
+                            "name": "windowOpenDetected",
                             "displayName": "Window open detected",
-                            "displayNameEvent": "Window open changed",
                             "type": "bool",
                             "defaultValue": false
                         },

--- a/tado/integrationplugintado.cpp
+++ b/tado/integrationplugintado.cpp
@@ -432,7 +432,7 @@ void IntegrationPluginTado::onZoneStateReceived(const QString &homeId, const QSt
     thing->setStateValue(zoneTargetTemperatureStateTypeId, state.settingTemperature);
     thing->setStateValue(zoneTemperatureStateTypeId, state.temperature);
     thing->setStateValue(zoneHumidityStateTypeId, state.humidity);
-    thing->setStateValue(zoneWindowOpenDetectedStateTypeId, state.windowOpen);
+    thing->setStateValue(zoneWindowOpenDetectedStateTypeId, state.windowOpenDetected);
     thing->setStateValue(zoneTadoModeStateTypeId, state.tadoMode);
 }
 

--- a/tado/integrationplugintado.cpp
+++ b/tado/integrationplugintado.cpp
@@ -432,7 +432,7 @@ void IntegrationPluginTado::onZoneStateReceived(const QString &homeId, const QSt
     thing->setStateValue(zoneTargetTemperatureStateTypeId, state.settingTemperature);
     thing->setStateValue(zoneTemperatureStateTypeId, state.temperature);
     thing->setStateValue(zoneHumidityStateTypeId, state.humidity);
-    thing->setStateValue(zoneWindowOpenStateTypeId, state.windowOpen);
+    thing->setStateValue(zoneWindowOpenDetectedStateTypeId, state.windowOpen);
     thing->setStateValue(zoneTadoModeStateTypeId, state.tadoMode);
 }
 

--- a/tado/integrationplugintado.h
+++ b/tado/integrationplugintado.h
@@ -31,12 +31,15 @@
 #ifndef INTEGRATIONPLUGINTADO_H
 #define INTEGRATIONPLUGINTADO_H
 
-#include "plugintimer.h"
-#include "integrations/integrationplugin.h"
-#include "network/oauth2.h"
 #include "tado.h"
+#include "extern-plugininfo.h"
+
+#include <plugintimer.h>
+#include <integrations/integrationplugin.h>
+#include <network/oauth2.h>
 
 #include <QHash>
+
 #include <QTimer>
 
 class IntegrationPluginTado : public IntegrationPlugin

--- a/tado/integrationplugintado.json
+++ b/tado/integrationplugintado.json
@@ -117,9 +117,8 @@
                         },
                         {
                             "id": "c7a04e26-bb22-406e-b117-262bdb8b9c0e",
-                            "name": "windowOpen",
-                            "displayName": "Window open",
-                            "displayNameEvent": "Window open changed",
+                            "name": "windowOpenDetected",
+                            "displayName": "Window open detected",
                             "type": "bool",
                             "defaultValue": false
                         },

--- a/tado/tado.cpp
+++ b/tado/tado.cpp
@@ -356,6 +356,7 @@ void Tado::getZoneState(const QString &homeId, const QString &zoneId)
             return;
         }
 
+
         setConnectionStatus(true);
         setAuthenticationStatus(true);
 
@@ -365,10 +366,11 @@ void Tado::getZoneState(const QString &homeId, const QString &zoneId)
             qDebug(dcTado()) << "Get Token: Recieved invalid JSON object";
             return;
         }
+        qCDebug(dcTado()) << "Zone status received:" << qUtf8Printable(data.toJson(QJsonDocument::Indented));
         ZoneState state;
         QVariantMap map = data.toVariant().toMap();
         state.tadoMode = map["tadoMode"].toString();
-        state.windowOpen = map["openWindow"].toBool();
+        state.windowOpenDetected = map["openWindowDetected"].toBool();
 
         QVariantMap settingsMap = map["setting"].toMap();
         state.settingType = settingsMap["type"].toString();

--- a/tado/tado.h
+++ b/tado/tado.h
@@ -75,7 +75,7 @@ public:
         bool settingPower = false;
         double temperature = false;
         double humidity = false;
-        bool windowOpen = false;
+        bool windowOpenDetected = false;
         double heatingPowerPercentage = false;
         QString heatingPowerType;
         bool overlayIsSet = false;


### PR DESCRIPTION
The interface now distinguishes between states that are informative (read only) and ones that can be set.

nymea-plugins pull request checklist:

- [x] Make sure the pull request's title is of format "Plugin name: Add support for xyz" or "New plugin: Plugin name"

- [x] Did you test the changes on hardware, if not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [x] Did you update the plugin's README.md accordingly?

- [x] Did you update translations (`cd builddir && make lupdate`)?
