### PR TITLE
EVBox: Fix processing erraneous packets that still pass the CRC check and a double action finish() call

### DIFF
--- a/evbox/evboxport.cpp
+++ b/evbox/evboxport.cpp
@@ -41,7 +41,6 @@
 #define ETX 0x03
 
 
-
 EVBoxPort::EVBoxPort(const QString &portName, QObject *parent)
     : QObject{parent}
 {
@@ -109,7 +108,10 @@ void EVBoxPort::onReadyRead()
 {
     m_waitTimer.start();
 
-    m_inputBuffer.append(m_serialPort->readAll());
+    QByteArray data = m_serialPort->readAll();
+    qCDebug(dcEVBox()) << "<--" << data;
+
+    m_inputBuffer.append(data);
 
     QByteArray packet;
     QDataStream inputStream(m_inputBuffer);
@@ -124,7 +126,15 @@ void EVBoxPort::onReadyRead()
                 startFound = true;
                 continue;
             } else {
-                qCWarning(dcEVBox()) << "Discarding byte not matching start of frame 0x" + QString::number(byte, 16);
+                qCWarning(dcEVBox()) << "Discarding byte 0x" + QString::number(byte, 16) + " which is not matching start of frame 0x" + QString::number(STX, 16);
+                continue;
+            }
+        } else {
+            // Sometimes the wallbox seems to stumble and restart packet transmission before a previous packet is finished...
+            // If we detect another STX before an ETX, let's discard it
+            if (byte == STX) {
+                qCWarning(dcEVBox()) << "Bogus data from wallbox detected. Discarding input buffers.";
+                m_inputBuffer.clear();
                 continue;
             }
         }
@@ -139,6 +149,8 @@ void EVBoxPort::onReadyRead()
 
     if (startFound && endFound) {
         m_inputBuffer.remove(0, packet.length() + 2);
+    } else if (!startFound) {
+        qCDebug(dcEVBox()) << "End of data but no start of frame header received.";
     } else {
         qCDebug(dcEVBox()) << "Data is incomplete... Waiting for more...";
         return;
@@ -149,7 +161,7 @@ void EVBoxPort::onReadyRead()
         return;
     }
 
-    qCDebug(dcEVBox()) << "<--" << packet;
+    qCDebug(dcEVBox()) << "Data packet received:" << packet;
 
     processDataPacket(packet);
 
@@ -220,7 +232,7 @@ void EVBoxPort::processDataPacket(const QByteArray &packet)
         return;
     }
 
-    qCDebug(dcEVBox()) << "Data packet received: From:" << from
+    qCDebug(dcEVBox()) << "Parsed data packet: From:" << from
                        << "To:" << to
                        << "Command:" << command
                        << "Serial:" << serial

--- a/evbox/integrationpluginevbox.cpp
+++ b/evbox/integrationpluginevbox.cpp
@@ -141,7 +141,7 @@ void IntegrationPluginEVBox::setupThing(ThingSetupInfo *info)
     // Setup routine: Try to set the max charging current to 6A and see if we get a valid answer
     port->sendCommand(EVBoxPort::Command68, 60, 6, serialNumber);
     connect(port, &EVBoxPort::closed, info, [info](){
-        info->finish(Thing::ThingErrorHardwareFailure, QT_TR_NOOP("The EVBox is has closed the connection."));
+        info->finish(Thing::ThingErrorHardwareFailure, QT_TR_NOOP("The EVBox has closed the connection."));
     });
     connect(port, &EVBoxPort::responseReceived, info, [info, serialNumber](EVBoxPort::Command /*command*/, const QString &serial){
         if (serial == serialNumber) {

--- a/evbox/integrationpluginevbox.cpp
+++ b/evbox/integrationpluginevbox.cpp
@@ -141,14 +141,14 @@ void IntegrationPluginEVBox::setupThing(ThingSetupInfo *info)
     // Setup routine: Try to set the max charging current to 6A and see if we get a valid answer
     port->sendCommand(EVBoxPort::Command68, 60, 6, serialNumber);
     connect(port, &EVBoxPort::closed, info, [info](){
-        info->finish(Thing::ThingErrorHardwareFailure, QT_TR_NOOP("The EVBox is not responding."));
+        info->finish(Thing::ThingErrorHardwareFailure, QT_TR_NOOP("The EVBox is has closed the connection."));
     });
     connect(port, &EVBoxPort::responseReceived, info, [info, serialNumber](EVBoxPort::Command /*command*/, const QString &serial){
         if (serial == serialNumber) {
             info->finish(Thing::ThingErrorNoError);
         }
     });
-    QTimer::singleShot(3000, info, [info](){
+    QTimer::singleShot(5000, info, [info](){
         info->finish(Thing::ThingErrorTimeout, QT_TR_NOOP("The EVBox is not responding."));
     });
 
@@ -272,7 +272,7 @@ void IntegrationPluginEVBox::executeAction(ThingActionInfo *info)
     }
 
     m_pendingActions[thing].append(info);
-    connect(info, &ThingActionInfo::finished, this, [=](){
+    connect(info, &ThingActionInfo::aborted, this, [=](){
         m_pendingActions[thing].removeAll(info);
     });
 
@@ -281,7 +281,7 @@ void IntegrationPluginEVBox::executeAction(ThingActionInfo *info)
 void IntegrationPluginEVBox::finishPendingAction(Thing *thing)
 {
     if (!m_pendingActions.value(thing).isEmpty()) {
-        ThingActionInfo *info = m_pendingActions.value(thing).first();
+        ThingActionInfo *info = m_pendingActions[thing].takeFirst();
         qCDebug(dcEVBox()) << "Finishing action:" << info->action().actionTypeId().toString();
         ActionType actionType = thing->thingClass().actionTypes().findById(info->action().actionTypeId());
         if (actionType.name() == "power") {


### PR DESCRIPTION
nymea-plugins pull request checklist:

- [x] Make sure the pull request's title is of format "Plugin name: Add support for xyz" or "New plugin: Plugin name"

- [x] Did you test the changes on hardware, if not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [x] Did you update the plugin's README.md accordingly?

- [x] Did you update translations (`cd builddir && make lupdate`)?
