### PR TITLE
Keba: Fix type mismatch warning on setState for phaseCount

### DIFF
--- a/keba/integrationpluginkeba.cpp
+++ b/keba/integrationpluginkeba.cpp
@@ -444,12 +444,12 @@ void IntegrationPluginKeba::setupKeba(ThingSetupInfo *info, const QHostAddress &
         thing->setStateValue("uptime", report.seconds / 60);
 
         if (thing->thingClassId() == kebaSimpleThingClassId) {
-            thing->setStateValue(kebaSimplePhaseCountStateTypeId, thing->setting(kebaSimpleThingClassId));
+            thing->setStateValue(kebaSimplePhaseCountStateTypeId, thing->setting(kebaSimpleThingClassId).toUInt());
         }
 
         connect(thing, &Thing::settingChanged, thing, [thing](const ParamTypeId &settingsTypeId, const QVariant &value){
             if (settingsTypeId == kebaSimpleSettingsPhaseCountParamTypeId) {
-                thing->setStateValue(kebaSimplePhaseCountStateTypeId, value);
+                thing->setStateValue(kebaSimplePhaseCountStateTypeId, value.toUInt());
             }
         });
     });


### PR DESCRIPTION
nymea-plugins pull request checklist:

- [ ] Make sure the pull request's title is of format "Plugin name: Add support for xyz" or "New plugin: Plugin name"

- [ ] Did you test the changes on hardware, if not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [ ] Did you update the plugin's README.md accordingly?

- [ ] Did you update translations (`cd builddir && make lupdate`)?
