### PR TITLE
Fronius: Add precise discovery

### DIFF
--- a/fronius/fronius.pro
+++ b/fronius/fronius.pro
@@ -3,11 +3,13 @@ include(../plugins.pri)
 QT += network
 
 SOURCES += \
+    froniusdiscovery.cpp \
     froniusnetworkreply.cpp \
     froniussolarconnection.cpp \
     integrationpluginfronius.cpp \
 
 HEADERS += \
+    froniusdiscovery.h \
     froniusnetworkreply.h \
     froniussolarconnection.h \
     integrationpluginfronius.h \

--- a/fronius/froniusdiscovery.cpp
+++ b/fronius/froniusdiscovery.cpp
@@ -1,0 +1,137 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+*
+* Copyright 2013 - 2023, nymea GmbH
+* Contact: contact@nymea.io
+*
+* This file is part of nymea.
+* This project including source code and documentation is protected by
+* copyright law, and remains the property of nymea GmbH. All rights, including
+* reproduction, publication, editing and translation, are reserved. The use of
+* this project is subject to the terms of a license agreement to be concluded
+* with nymea GmbH in accordance with the terms of use of nymea GmbH, available
+* under https://nymea.io/license
+*
+* GNU Lesser General Public License Usage
+* Alternatively, this project may be redistributed and/or modified under the
+* terms of the GNU Lesser General Public License as published by the Free
+* Software Foundation; version 3. This project is distributed in the hope that
+* it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+* warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with this project. If not, see <https://www.gnu.org/licenses/>.
+*
+* For any further details and any questions please contact us under
+* contact@nymea.io or see our FAQ/Licensing Information on
+* https://nymea.io/license/faq
+*
+* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "froniusdiscovery.h"
+
+#include "extern-plugininfo.h"
+
+#include <QJsonDocument>
+#include <QJsonParseError>
+
+FroniusDiscovery::FroniusDiscovery(NetworkAccessManager *networkManager, NetworkDeviceDiscovery *networkDeviceDiscovery, QObject *parent):
+    QObject(parent),
+    m_networkManager(networkManager),
+    m_networkDeviceDiscovery{networkDeviceDiscovery}
+{
+    m_gracePeriodTimer.setSingleShot(true);
+    m_gracePeriodTimer.setInterval(3000);
+    connect(&m_gracePeriodTimer, &QTimer::timeout, this, [this](){
+        qCDebug(dcFronius()) << "Discovery: Grace period timer triggered.";
+        finishDiscovery();
+    });
+
+}
+
+void FroniusDiscovery::startDiscovery()
+{
+    qCInfo(dcFronius()) << "Discovery: Searching for Fronius solar devices in the network...";
+    NetworkDeviceDiscoveryReply *discoveryReply = m_networkDeviceDiscovery->discover();
+
+    connect(discoveryReply, &NetworkDeviceDiscoveryReply::networkDeviceInfoAdded, this, &FroniusDiscovery::checkNetworkDevice);
+
+    connect(discoveryReply, &NetworkDeviceDiscoveryReply::finished, this, [=](){
+        qCDebug(dcFronius()) << "Discovery: Network discovery finished. Found" << discoveryReply->networkDeviceInfos().count() << "network devices";
+        m_gracePeriodTimer.start();
+        discoveryReply->deleteLater();
+    });
+}
+
+QList<NetworkDeviceInfo> FroniusDiscovery::discoveryResults() const
+{
+    return m_discoveryResults;
+}
+
+void FroniusDiscovery::checkNetworkDevice(const NetworkDeviceInfo &networkDeviceInfo)
+{
+    qCDebug(dcFronius()) << "Checking network device:" << networkDeviceInfo;
+
+    FroniusSolarConnection *connection = new FroniusSolarConnection(m_networkManager, networkDeviceInfo.address(), this);
+    m_connections.append(connection);
+
+    FroniusNetworkReply *reply = connection->getVersion();
+    connect(reply, &FroniusNetworkReply::finished, this, [=] {
+        QByteArray data = reply->networkReply()->readAll();
+        if (reply->networkReply()->error() != QNetworkReply::NoError) {
+            if (reply->networkReply()->error() == QNetworkReply::ContentNotFoundError) {
+                qCInfo(dcFronius()) << "The device does not reply to our requests. Please verify that the Fronius Solar API is enabled on the device.";
+            } else {
+                qCDebug(dcFronius()) << "device" << networkDeviceInfo.address() << "is not reachable.";
+            }
+            cleanupConnection(connection);
+            return;
+        }
+
+        QJsonParseError error;
+        QJsonDocument jsonDoc = QJsonDocument::fromJson(data, &error);
+        if (error.error != QJsonParseError::NoError) {
+            qCWarning(dcFronius()) << "Failed to parse JSON data" << data << ":" << error.errorString() << data;
+            cleanupConnection(connection);
+            return;
+        }
+
+        QVariantMap versionResponseMap = jsonDoc.toVariant().toMap();
+        if (!versionResponseMap.contains("CompatibilityRange")) {
+            qCInfo(dcFronius()) << "Unexpected JSON reply. PRobably not a Fronius device.";
+            cleanupConnection(connection);
+            return;
+        }
+        qCDebug(dcFronius()) << "Compatibility version" << versionResponseMap.value("CompatibilityRange").toString();
+
+        // Knwon version with broken JSON API. Still allowing to discover so the user will get a proper error message during setup
+        if (versionResponseMap.value("CompatibilityRange").toString() == "1.6-2") {
+            qCWarning(dcFronius()) << "The Fronius data logger has a version which is known to have a broken JSON API firmware.";
+        }
+
+        m_discoveryResults.append(networkDeviceInfo);
+        cleanupConnection(connection);
+    });
+}
+
+void FroniusDiscovery::cleanupConnection(FroniusSolarConnection *connection)
+{
+    m_connections.removeAll(connection);
+    connection->deleteLater();
+}
+
+void FroniusDiscovery::finishDiscovery()
+{
+    qint64 durationMilliSeconds = QDateTime::currentMSecsSinceEpoch() - m_startDateTime.toMSecsSinceEpoch();
+
+    foreach (FroniusSolarConnection *connection, m_connections) {
+        cleanupConnection(connection);
+    }
+
+    qCInfo(dcFronius()) << "Discovery: Finished the discovery process. Found" << m_discoveryResults.count()
+                       << "Fronius devices in" << QTime::fromMSecsSinceStartOfDay(durationMilliSeconds).toString("mm:ss.zzz");
+    m_gracePeriodTimer.stop();
+
+    emit discoveryFinished();
+
+}

--- a/fronius/froniusdiscovery.h
+++ b/fronius/froniusdiscovery.h
@@ -1,0 +1,70 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+*
+* Copyright 2013 - 2023, nymea GmbH
+* Contact: contact@nymea.io
+*
+* This file is part of nymea.
+* This project including source code and documentation is protected by
+* copyright law, and remains the property of nymea GmbH. All rights, including
+* reproduction, publication, editing and translation, are reserved. The use of
+* this project is subject to the terms of a license agreement to be concluded
+* with nymea GmbH in accordance with the terms of use of nymea GmbH, available
+* under https://nymea.io/license
+*
+* GNU Lesser General Public License Usage
+* Alternatively, this project may be redistributed and/or modified under the
+* terms of the GNU Lesser General Public License as published by the Free
+* Software Foundation; version 3. This project is distributed in the hope that
+* it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+* warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with this project. If not, see <https://www.gnu.org/licenses/>.
+*
+* For any further details and any questions please contact us under
+* contact@nymea.io or see our FAQ/Licensing Information on
+* https://nymea.io/license/faq
+*
+* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef FRONIUSDISCOVERY_H
+#define FRONIUSDISCOVERY_H
+
+#include <QObject>
+#include <QTimer>
+
+#include <network/networkdevicediscovery.h>
+#include "froniussolarconnection.h"
+
+class FroniusDiscovery : public QObject
+{
+    Q_OBJECT
+public:
+    explicit FroniusDiscovery(NetworkAccessManager *networkManager, NetworkDeviceDiscovery *networkDeviceDiscovery, QObject *parent = nullptr);
+
+    void startDiscovery();
+
+    QList<NetworkDeviceInfo> discoveryResults() const;
+
+signals:
+    void discoveryFinished();
+
+private:
+    NetworkAccessManager *m_networkManager = nullptr;
+    NetworkDeviceDiscovery *m_networkDeviceDiscovery = nullptr;
+
+    QTimer m_gracePeriodTimer;
+    QDateTime m_startDateTime;
+
+    QList<FroniusSolarConnection *> m_connections;
+
+    QList<NetworkDeviceInfo> m_discoveryResults;
+
+    void checkNetworkDevice(const NetworkDeviceInfo &networkDeviceInfo);
+    void cleanupConnection(FroniusSolarConnection *connection);
+
+    void finishDiscovery();
+};
+
+#endif // FRONIUSDISCOVERY_H

--- a/fronius/froniussolarconnection.cpp
+++ b/fronius/froniussolarconnection.cpp
@@ -46,6 +46,30 @@ QHostAddress FroniusSolarConnection::address() const
     return m_address;
 }
 
+void FroniusSolarConnection::setAddress(const QHostAddress &address)
+{
+    if (m_address == address)
+        return;
+
+    m_address = address;
+
+    // The address has changed, let's clean up any queue and refresh
+
+    // Note: the destructor will take care about the cleanup of any pending replies
+    qDeleteAll(m_requestQueue);
+    m_requestQueue.clear();
+
+    if (m_currentReply) {
+        m_currentReply->deleteLater();
+        m_currentReply = nullptr;
+    }
+
+    if (m_address.isNull()) {
+        m_available = false;
+        emit availableChanged(m_available);
+    }
+}
+
 bool FroniusSolarConnection::available() const
 {
     return m_available;

--- a/fronius/froniussolarconnection.h
+++ b/fronius/froniussolarconnection.h
@@ -32,7 +32,6 @@
 #define FRONIUSSOLARCONNECTION_H
 
 #include <QObject>
-
 #include <QQueue>
 #include <QHostAddress>
 
@@ -47,6 +46,7 @@ public:
     explicit FroniusSolarConnection(NetworkAccessManager *networkManager, const QHostAddress &address, QObject *parent = nullptr);
 
     QHostAddress address() const;
+    void setAddress(const QHostAddress &address);
 
     bool available() const;
 

--- a/fronius/integrationpluginfronius.h
+++ b/fronius/integrationpluginfronius.h
@@ -31,13 +31,11 @@
 #ifndef INTEGRATIONPLUGINFRONIUS_H
 #define INTEGRATIONPLUGINFRONIUS_H
 
-#include "integrations/integrationplugin.h"
-#include "froniussolarconnection.h"
+#include <integrations/integrationplugin.h>
+#include <network/networkaccessmanager.h>
+#include <network/networkdevicediscovery.h>
 
-#include <QHash>
-#include <QNetworkReply>
-#include <QTimer>
-#include <QUuid>
+#include "froniussolarconnection.h"
 
 class PluginTimer;
 
@@ -60,6 +58,7 @@ private:
     PluginTimer *m_connectionRefreshTimer = nullptr;
 
     QHash<FroniusSolarConnection *, Thing *> m_froniusConnections;
+    QHash<Thing *, NetworkDeviceMonitor *> m_monitors;
 
     void refreshConnection(FroniusSolarConnection *connection);
 

--- a/fronius/integrationpluginfronius.json
+++ b/fronius/integrationpluginfronius.json
@@ -22,7 +22,7 @@
                             "displayName": "Host address",
                             "type": "QString",
                             "inputType": "IPv4Address",
-                            "defaultValue": "88.117.152.99"
+                            "defaultValue": ""
                         },
                         {
                             "id": "2237972e-385b-4458-b5d3-1d1fb4ae8756",


### PR DESCRIPTION
This isn't good yet. Discovery needs to be reworked to properly detect the fronius api instead.

nymea-plugins pull request checklist:

- [x] Make sure the pull request's title is of format "Plugin name: Add support for xyz" or "New plugin: Plugin name"

- [x] Did you test the changes on hardware, if not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [ ] Did you update the plugin's README.md accordingly?

- [ ] Did you update translations (`cd builddir && make lupdate`)?
