### PR TITLE
Shelly: Fix discovery for 1 Plus PM

### DIFF
--- a/shelly/integrationpluginshelly.cpp
+++ b/shelly/integrationpluginshelly.cpp
@@ -90,7 +90,7 @@ void IntegrationPluginShelly::discoverThings(ThingDiscoveryInfo *info)
         } else if (info->thingClassId() == shelly1pmThingClassId) {
             namePattern = QRegExp("^shelly1pm-[0-9A-Z]+$");
         } else if (info->thingClassId() == shellyPlus1pmThingClassId) {
-            namePattern = QRegExp("^ShellyPlus1PM-[0-9A-Z]+$");
+            namePattern = QRegExp("^ShellyPlus1PM-[0-9A-Z]+$", Qt::CaseInsensitive);
         } else if (info->thingClassId() == shelly1lThingClassId) {
             namePattern = QRegExp("^shelly1l-[0-9A-Z]+$");
         } else if (info->thingClassId() == shellyPlugThingClassId) {


### PR DESCRIPTION
nymea-plugins pull request checklist:

- [x] Make sure the pull request's title is of format "Plugin name: Add support for xyz" or "New plugin: Plugin name"

- [ ] Did you test the changes on hardware, if not (e.g. absence of required hardware), please mention a person to confirm it has been tested. I don't have a linux box available at the moment to compile nymea.

- [ ] Did you update the plugin's README.md accordingly? There's no change to the features of the plugin

- [ ] Did you update translations (`cd builddir && make lupdate`)? Not required

This change is simply to make regexp case insensitive for discovery of Shelly Plus 1PM. This is necessary because some device show with only lower case. The change was done only for Shelly Plus 1PM, but it could make sense to do it for all the Shelly devices.