### PR TITLE
MailNotification: Fix double mail ending

### DIFF
--- a/mailnotification/smtpclient.cpp
+++ b/mailnotification/smtpclient.cpp
@@ -351,7 +351,7 @@ void SmtpClient::processServerResponse(int responseCode, const QString &response
         break;
     case StateBody:
         if (responseCode == 354) {
-            send(m_messageData + "\r\n.\r\n");
+            send(m_messageData);
             setState(StateQuit);
         } else {
             handleUnexpectedSmtpCode(responseCode, response);


### PR DESCRIPTION
The message body is already composed using a \r\n.\r\n at the end, and the actual sending process appended an extra one. While apparently the plugin was working with most mail servers, the double \r\n.\r\n at the end violates the spec and newer OpenSMTP servers are rejecting this.

nymea-plugins pull request checklist:

- [ ] Make sure the pull request's title is of format "Plugin name: Add support for xyz" or "New plugin: Plugin name"

- [ ] Did you test the changes on hardware, if not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [ ] Did you update the plugin's README.md accordingly?

- [ ] Did you update translations (`cd builddir && make lupdate`)?
