### PR TITLE
Update README.md Unifi Plugin

### DIFF
--- a/unifi/README.md
+++ b/unifi/README.md
@@ -1,11 +1,15 @@
 # UniFi
 
-This plugin adds support to connect nymea to a UniFi network controller and monitor devices for presence.
+This plugin adds support to connect nymea to a UniFi network controller and monitor devices for presence.<br />
+UniFi distinguishs between Controller running on a UniFi Console and Controller running on a Windows, macOS or Linux machine.
 
 ## Usage
 
-In order to monitor network devices via a UniFi controller, it is required to configure the UniFi controller.
-The IP, as well as username and password for the UniFi controller must be provided.
+In order to monitor network devices via a UniFi controller, it is required to configure the UniFi controller.<br />
+The IP, as well as username and password for the UniFi controller must be provided. The port is optional.<br /> 
+For Controller running on a UniFi console the port must be 443. Network controller running on Windows, macOS or Linux machines <br />
+usually use port 8443. This is also the default value if empty.<br />
+The login-user must have a local access only for the controller, a user with cloud access will not work.
 
 Once the controller is added to the system, additional Wi-Fi devices may be added by starting a discovery of
 UniFi clients. After a client is addded, it will appear as presence sensor in the system.


### PR DESCRIPTION
already prepared an update for the Unifi plugin containg the following changes:
- difference between Hardware and software-based controllers
- description of the port field and its different values
- made clear that only local users can login

please wait with publishing until the latest plugin with the described changes is in experimental and I could test it.

Thanks.




nymea-plugins pull request checklist:

- [ ] Make sure the pull request's title is of format "Plugin name: Add support for xyz" or "New plugin: Plugin name"

- [ ] Did you test the changes on hardware, if not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [ ] Did you update the plugin's README.md accordingly?

- [ ] Did you update translations (`cd builddir && make lupdate`)?
