### PR TITLE
Awattar: Add a ranking state for simple use in rules

### DIFF
--- a/awattar/README.md
+++ b/awattar/README.md
@@ -16,6 +16,8 @@ In the following chart you can see an example of the market prices from -12 hour
 * +100 % current price equals highest price in the interval [-12h `<` now `<` + 12h]
 
 ![aWATTar graph](https://raw.githubusercontent.com/guh/nymea-plugins/master/awattar/docs/images/awattar-graph.png "aWATTar graph")
+
+Additionally, the plugin holds a rank for the current slot. 0 Indicates the cheapest slot of the interval [-12h `<` now `<` + 12h].
  
 ## Requirements
 

--- a/awattar/integrationpluginawattar.json
+++ b/awattar/integrationpluginawattar.json
@@ -79,6 +79,15 @@
                             "type": "double",
                             "unit": "EuroCentPerKiloWattHour",
                             "defaultValue": 0
+                        },
+                        {
+                            "id": "8af49ba8-0aba-4f09-ab11-533dcd19e873",
+                            "name": "rank",
+                            "displayName": "Current rank (lower is better)",
+                            "type": "uint",
+                            "minValue": 0,
+                            "maxValue": 100,
+                            "defaultValue": 100
                         }
                     ]
                 },
@@ -153,6 +162,15 @@
                             "type": "double",
                             "unit": "EuroCentPerKiloWattHour",
                             "defaultValue": 0
+                        },
+                        {
+                            "id": "f3a2a46f-e281-4f60-9d27-345264b67f9a",
+                            "name": "rank",
+                            "displayName": "Current rank (lower is better)",
+                            "type": "uint",
+                            "minValue": 0,
+                            "maxValue": 100,
+                            "defaultValue": 100
                         }
                     ]
                 }


### PR DESCRIPTION
Allows to do stuff when ranking indicates the current slots is in top x for the day.

Also fixes a bug that the current value hasn't been taken into account when calculating averages/deviations

nymea-plugins pull request checklist:

- [x] Make sure the pull request's title is of format "Plugin name: Add support for xyz" or "New plugin: Plugin name"

- [x] Did you test the changes on hardware, if not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [x] Did you update the plugin's README.md accordingly?

- [ ] Did you update translations (`cd builddir && make lupdate`)?
