### PR TITLE
Shelly: Improve debug logging when offline

### DIFF
--- a/shelly/integrationpluginshelly.cpp
+++ b/shelly/integrationpluginshelly.cpp
@@ -768,30 +768,30 @@ void IntegrationPluginShelly::joinMulticastGroup()
 {
     if (m_coap->joinMulticastGroup()) {
         qCInfo(dcShelly()) << "Joined CoIoT multicast group";
-        m_multicastRetryCnt = 0;
+        m_multicastWarningPrintCount = 0;
     } else {
-        uint retryTime = 0;
+        uint mod = m_multicastWarningPrintCount % 120;
 
         // FIXME: It would probably be better to monitor the network interfaces and re-join if necessary
-        if (m_multicastRetryCnt < 12) {
+        if (m_multicastWarningPrintCount < 12) {
             qCWarning(dcShelly()) << "Failed to join CoIoT multicast group. Retrying in 5 seconds...";
-            retryTime = 5000;
-        } else {
-            qCWarning(dcShelly()) << "Failed to join CoIoT multicast group. Retrying in 10 minutes...";
-            retryTime = 600000;
         }
 
-        QTimer::singleShot(retryTime, m_coap, [this](){
+        if (m_multicastWarningPrintCount >= 12 && mod == 0) {
+            qCWarning(dcShelly()) << "Failed to join CoIoT multicast group. Retrying in 10 minutes...";
+        }
+
+        QTimer::singleShot(5000, m_coap, [this](){
             joinMulticastGroup();
         });
-        m_multicastRetryCnt++;
+        m_multicastWarningPrintCount++;
     }
 }
 
 void IntegrationPluginShelly::onMulticastMessageReceived(const QHostAddress &source, const CoapPdu &pdu)
 {
     Q_UNUSED(source)
-//    qCDebug(dcShelly()) << "Multicast message received" << source << pdu;
+    //    qCDebug(dcShelly()) << "Multicast message received" << source << pdu;
     if (pdu.reqRspCode() != 0x1e) {
         // Not a shelly CoIoT status message (ReqRsp code "0.30")
         return;
@@ -1502,7 +1502,7 @@ void IntegrationPluginShelly::setupGen1(ThingSetupInfo *info)
                 rollerShutterChild.setParams(ParamList() << Param(shellyRollerThingChannelParamTypeId, 1));
                 autoChilds.append(rollerShutterChild);
 
-            // Create 2 measurement channels for shelly 2.5 (unless in roller mode)
+                // Create 2 measurement channels for shelly 2.5 (unless in roller mode)
             } else if (info->thing()->thingClassId() == shelly25ThingClassId) {
                 ThingDescriptor channelChild(shellyPowerMeterChannelThingClassId, info->thing()->name() + " channel 1", QString(), info->thing()->id());
                 channelChild.setParams(ParamList() << Param(shellyPowerMeterChannelThingChannelParamTypeId, 1));
@@ -1555,17 +1555,17 @@ void IntegrationPluginShelly::setupGen1(ThingSetupInfo *info)
     });
 
     // For testing and debugging, introspect the coap API. Allows introspecting the coap api on the device
-//    url.clear();
-//    url.setScheme("coap");
-//    url.setHost(address.toString());
-//    url.setPath("/cit/d");
+    //    url.clear();
+    //    url.setScheme("coap");
+    //    url.setHost(address.toString());
+    //    url.setPath("/cit/d");
 
-//    CoapRequest coapRequest(url);
-//    CoapReply *coapReply = m_coap->get(coapRequest);
-//    qCDebug(dcShelly) << "Coap request" << url;
-//    connect(coapReply, &CoapReply::finished, thing, [=](){
-//        qCDebug(dcShelly) << "Coap reply" << coapReply->error() << qUtf8Printable(QJsonDocument::fromJson(coapReply->payload()).toJson());
-//    });
+    //    CoapRequest coapRequest(url);
+    //    CoapReply *coapReply = m_coap->get(coapRequest);
+    //    qCDebug(dcShelly) << "Coap request" << url;
+    //    connect(coapReply, &CoapReply::finished, thing, [=](){
+    //        qCDebug(dcShelly) << "Coap reply" << coapReply->error() << qUtf8Printable(QJsonDocument::fromJson(coapReply->payload()).toJson());
+    //    });
 
 
     // Handle thing settings of gateway devices
@@ -1718,7 +1718,7 @@ void IntegrationPluginShelly::setupGen2(ThingSetupInfo *info)
                             ThingDescriptor rollerShutterChild(shellyRollerThingClassId, info->thing()->name() + " connected shutter", QString(), info->thing()->id());
                             rollerShutterChild.setParams(ParamList() << Param(shellyRollerThingChannelParamTypeId, 1));
                             children.append(rollerShutterChild);
-                        // Create 2 measurement channels for Shelly Plus 2PM (unless in roller mode)
+                            // Create 2 measurement channels for Shelly Plus 2PM (unless in roller mode)
                         }  else {
                             ThingDescriptor channelChild(shellyPowerMeterChannelThingClassId, info->thing()->name() + " channel 1", QString(), info->thing()->id());
                             channelChild.setParams(ParamList() << Param(shellyPowerMeterChannelThingChannelParamTypeId, 1));
@@ -2092,9 +2092,9 @@ QHostAddress IntegrationPluginShelly::getIP(Thing *thing) const
 bool IntegrationPluginShelly::isGen2(const QString &shellyId) const
 {
     return shellyId.contains("Plus", Qt::CaseInsensitive)
-                || shellyId.contains("Pro", Qt::CaseInsensitive)
-                || QRegExp("^(ShellyPlusPlugS|ShellyPlug(US|IT|UK))-[0-9A-Z]+$", Qt::CaseInsensitive).exactMatch(shellyId) // Plus plug variants need to be matched quite precisely to not also match the v1 Plug
-                ;
+            || shellyId.contains("Pro", Qt::CaseInsensitive)
+            || QRegExp("^(ShellyPlusPlugS|ShellyPlug(US|IT|UK))-[0-9A-Z]+$", Qt::CaseInsensitive).exactMatch(shellyId) // Plus plug variants need to be matched quite precisely to not also match the v1 Plug
+            ;
 }
 
 void IntegrationPluginShelly::handleInputEvent(Thing *thing, const QString &buttonName, const QString &inputEventString, int inputEventCount)

--- a/shelly/integrationpluginshelly.h
+++ b/shelly/integrationpluginshelly.h
@@ -94,6 +94,7 @@ private:
     PluginTimer *m_reconfigureTimer = nullptr;
 
     Coap *m_coap = nullptr;
+    uint m_multicastRetryCnt = 0;
 
     QHash<Thing*, ShellyJsonRpcClient*> m_rpcClients;
 };

--- a/shelly/integrationpluginshelly.h
+++ b/shelly/integrationpluginshelly.h
@@ -94,7 +94,7 @@ private:
     PluginTimer *m_reconfigureTimer = nullptr;
 
     Coap *m_coap = nullptr;
-    uint m_multicastRetryCnt = 0;
+    uint m_multicastWarningPrintCount = 0;
 
     QHash<Thing*, ShellyJsonRpcClient*> m_rpcClients;
 };


### PR DESCRIPTION
When shelly integration can't join the multicast group it begins spaming the log each 5s. With this commit it log the joining problem each 5s for the first Minute, after that each 10min.

nymea-plugins pull request checklist:

- [x] Make sure the pull request's title is of format "Plugin name: Add support for xyz" or "New plugin: Plugin name"

- [ ] Did you test the changes on hardware, if not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [ ] Did you update the plugin's README.md accordingly?

- [ ] Did you update translations (`cd builddir && make lupdate`)?
