### PR TITLE
Add optional newline setting for TCP client

### DIFF
--- a/tcpcommander/integrationplugintcpcommander.cpp
+++ b/tcpcommander/integrationplugintcpcommander.cpp
@@ -122,7 +122,11 @@ void IntegrationPluginTcpCommander::executeAction(ThingActionInfo *info)
 
     if (action.actionTypeId() == tcpClientTriggerActionTypeId) {
         QTcpSocket *tcpSocket = m_tcpSockets.value(thing);
-        QByteArray data = action.param(tcpClientTriggerActionDataParamTypeId).value().toByteArray();
+        QString dataString = action.param(tcpClientTriggerActionDataParamTypeId).value().toString();
+        if (thing->setting(tcpClientSettingsAppendNewlineParamTypeId).toBool() && !dataString.endsWith('\n')) {
+            dataString.append('\n');
+        }
+        QByteArray data = dataString.toUtf8();
         qint64 len = tcpSocket->write(data);
         if (len == data.length()) {
             info->finish(Thing::ThingErrorNoError);

--- a/tcpcommander/integrationplugintcpcommander.json
+++ b/tcpcommander/integrationplugintcpcommander.json
@@ -41,6 +41,15 @@
                             "displayNameEvent": "Connection status changed"
                         }
                     ],
+                    "settingsTypes": [
+                        {
+                            "id": "902a880c-9167-4ef7-9c80-f18e666a14ea",
+                            "name": "appendNewline",
+                            "displayName": "Append newline to sent data",
+                            "type": "bool",
+                            "defaultValue": false
+                        }
+                    ],
                     "actionTypes": [
                         {
                             "id": "6bc52462-b192-46a4-a6df-92cc5a479c89",


### PR DESCRIPTION
## Summary
- add a TCP client thing setting to optionally append a newline to outgoing data
- honor the new setting in the TCP client action handler when sending data

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68ef541d23e48331af85325942fc48d9